### PR TITLE
Fix GtkDialog

### DIFF
--- a/test/gui/dialogs.jl
+++ b/test/gui/dialogs.jl
@@ -16,4 +16,11 @@ save_dialog("Pick a filename", main_window; timeout = 0.25)
 
 color_dialog("What is your favorite color?", main_window; timeout = 0.25)
 
+dlg = GtkDialog("General dialog",  
+                Dict("Cancel" => Gtk4.ResponseType_CANCEL,
+                     "OK"=> Gtk4.ResponseType_ACCEPT), 
+                      Gtk4.DialogFlags_MODAL )
+show(dlg)
+destroy(dlg)
+
 end


### PR DESCRIPTION
GtkDialog was not working and this is my attempt at fixing it.

During the fix I had problems with this auto generated definition
```julia
  mutable struct GtkDialogLeaf <: GtkDialog
      handle::Ptr{GObject}
      function GtkDialogLeaf(handle::Ptr{GObject}, owns = false)
          if handle == C_NULL
              error("Cannot construct GtkDialogLeaf with a NULL pointer")
          end
          GLib.gobject_maybe_sink(handle, owns)
          return gobject_ref(new(handle))
      end
  end
  local kwargs
  function GtkDialogLeaf(args...; kwargs...)
      w = GtkDialog(args...)
      for (kw, val) = kwargs
          set_gtk_property!(w, kw, val)
      end
      w
  end
  gtype_wrapper_cache[:GtkDialog] = GtkDialogLeaf
  function GtkDialog(args...; kwargs...)
      GtkDialogLeaf(args...; kwargs...)
  end
```

I don't understand the second and third constructor, which would call each other recursively.
Wouldn't the following make more sense?
```julia
mutable struct GtkDialogLeaf <: GtkDialog
    handle::Ptr{GObject}
    function GtkDialogLeaf(handle::Ptr{GObject}, owns = false; kwargs...)
        if handle == C_NULL
            error("Cannot construct GtkDialogLeaf with a NULL pointer")
        end
        GLib.gobject_maybe_sink(handle, owns)
        w = gobject_ref(new(handle))
        for (kw, val) = kwargs
            set_gtk_property!(w, kw, val)
        end
        w
    end
end
gtype_wrapper_cache[:GtkDialog] = GtkDialogLeaf
function GtkDialog(args...; kwargs...)
    GtkDialogLeaf(args...; kwargs...)
end
```