### PR TITLE
Asynchronous implementation of open_file

### DIFF
--- a/test/gui/dialogs.jl
+++ b/test/gui/dialogs.jl
@@ -16,4 +16,11 @@ save_dialog("Pick a filename", main_window; timeout = 0.25)
 
 color_dialog("What is your favorite color?", main_window; timeout = 0.25)
 
+dlg = GtkDialog("General dialog",  
+                Dict("Cancel" => Gtk4.ResponseType_CANCEL,
+                     "OK"=> Gtk4.ResponseType_ACCEPT), 
+                      Gtk4.DialogFlags_MODAL )
+show(dlg)
+destroy(dlg)
+
 end


### PR DESCRIPTION
One issue with the current implementation of `open_file` etc. is that it does not work within a callback. But it is not so uncommon to open a file when pressing some button.

Therefore I suggest providing both the synchronous and the asynchronous implementation. The later is called like this:
```julia
open_dialog("Pick a file to open") do filename
    @info filename
end
```
Within a callback it would be used like this:
```julia
signal_connect(b, "clicked") do widget
    open_dialog("Pick a file to open") do filename
        @info filename
    end
end
``` 