### PR TITLE
Fix method error in GtkCanvas on_resize

### DIFF
--- a/src/cairo.jl
+++ b/src/cairo.jl
@@ -30,6 +30,7 @@ mutable struct GtkCanvas <: GtkDrawingArea # NOT a GType
             nothing
         end
 
+        on_resize(da::GtkDrawingArea, width::Int64, height::Int64) = on_resize(da, Cint(width), Cint(height))
         function on_resize(da::GtkDrawingArea, width::Cint, height::Cint)
             widget.is_sized = true
             if G_.get_realized(widget)

--- a/src/cairo.jl
+++ b/src/cairo.jl
@@ -30,7 +30,7 @@ mutable struct GtkCanvas <: GtkDrawingArea # NOT a GType
             nothing
         end
 
-        on_resize(da::GtkDrawingArea, width::Int64, height::Int64) = on_resize(da, Cint(width), Cint(height))
+        on_resize(da::GtkDrawingArea, width, height) = on_resize(da, Cint(width), Cint(height))
         function on_resize(da::GtkDrawingArea, width::Cint, height::Cint)
             widget.is_sized = true
             if G_.get_realized(widget)


### PR DESCRIPTION
I've found and fixed a MethodError with the GtkCanvas on_resize method. This error is for example triggered by the on_realize method in the same file, which uses Int64 instead of Cint