### PR TITLE
Add GtkCustomFilter constructor and filtered list view example

### DIFF
--- a/examples/filteredlistview.jl
+++ b/examples/filteredlistview.jl
@@ -1,0 +1,45 @@
+using Gtk4, Gtk4.GLib
+
+win = GtkWindow("Listview demo with filter")
+box = GtkBox(:v)
+entry = GtkSearchEntry()
+sw = GtkScrolledWindow()
+push!(box, entry)
+push!(box, sw)
+push!(win, box)
+
+modelValues = string.(names(Gtk4))
+model = GtkStringList(modelValues)
+factory = GtkSignalListItemFactory()
+
+function setup_cb(f, li)
+    set_child(li,GtkLabel(""))
+end
+
+function bind_cb(f, li)
+    text = li[].string
+    label = get_child(li)
+    label.label = text
+end
+
+function match(list_item, user_data)
+  itemLeaf = Gtk4.GLib.find_leaf_type(list_item)
+  item = convert(itemLeaf, list_item)
+  result = startswith(item.string, entry.text)
+  return result ? Cint(1) : Cint(0)
+end
+
+filter = GtkCustomFilter((li, ud) -> match(li, ud))
+filteredModel = GtkFilterListModel(GLib.GListModel(model), filter)
+
+list = GtkListView(GtkSelectionModel(GtkSingleSelection(GLib.GListModel(filteredModel))), factory)
+list.vexpand = true
+
+signal_connect(setup_cb, factory, "setup")
+signal_connect(bind_cb, factory, "bind")
+
+signal_connect(entry, :search_changed) do w
+  @idle_add Gtk4.G_.changed(filter, Gtk4.FilterChange_DIFFERENT) 
+end
+
+sw[] = list

--- a/src/lists.jl
+++ b/src/lists.jl
@@ -73,3 +73,11 @@ function GtkTreeListModel(root::GListModel, passthrough, autoexpand, create_func
     ret = ccall(("gtk_tree_list_model_new", libgtk4), Ptr{GObject}, (Ptr{GObject}, Cint, Cint, Ptr{Nothing}, Ptr{Nothing}, Ptr{Nothing}), root, passthrough, autoexpand, create_cfunc, C_NULL, C_NULL)
     convert(GtkTreeListModel, ret, true)
 end
+
+## GtkCustomFilter
+
+function GtkCustomFilter(match::Function)
+    create_cfunc = @cfunction($match, Cint, (Ptr{GObject}, Ptr{Nothing}))
+    ret = ccall(("gtk_custom_filter_new", libgtk4), Ptr{GObject}, (Ptr{Nothing}, Ptr{Nothing}, Ptr{Nothing}), create_cfunc, C_NULL, C_NULL)
+    convert(GtkCustomFilter, ret, true)
+end


### PR DESCRIPTION
Hello! I'm currently working a bit of larger GUI for configuring a tree of settings and I'm trying to use (or rather struggling with my understanding of) the new Gtk4 List API.

I've been following the provided list view example and the recommendations from this issue: https://github.com/JuliaGtk/Gtk4.jl/issues/29. So far I've managed to display overview of the tree-nodes with TreeListModel and a seperate ListModel, both with custom sub-widgets. Most of it is still a bit unstable and I run into frequent segmentation faults.

To get filtering to work I had to add a GtkCustomFilter constructor, because the (automatically?) generated constructor could not find CustomFilter_new. I've also added a small example that shows the filtering in action. This PR adds both these changes. If I get the reminder of my GUI to be stable, I could later also add an example for a tree