### PR TITLE
Add GtkListBox wrapper and example (with filtering)

### DIFF
--- a/examples/listbox.jl
+++ b/examples/listbox.jl
@@ -1,0 +1,28 @@
+using Gtk4
+
+win = GtkWindow("ListBox demo with filter")
+box = GtkBox(:v)
+entry = GtkSearchEntry()
+sw = GtkScrolledWindow()
+push!(box, entry)
+push!(box, sw)
+push!(win, box)
+
+listBox = GtkListBox()
+foreach(x-> push!(listBox, GtkLabel(x)), string.(names(Gtk4)))
+
+function match(ptr, _)
+  row = convert(GtkListBoxRowLeaf, ptr)
+  label = row.child
+  result = startswith(label.label, entry.text)
+  return result ? Cint(1) : Cint(0)
+end
+
+Gtk4.set_filter_func(listBox, (row, data) -> match(row, data))
+
+signal_connect(entry, :search_changed) do w
+  @idle_add Gtk4.G_.invalidate_filter(listBox) 
+end
+
+sw[] = listBox
+listBox.vexpand = true

--- a/src/lists.jl
+++ b/src/lists.jl
@@ -74,6 +74,25 @@ function GtkTreeListModel(root::GListModel, passthrough, autoexpand, create_func
     convert(GtkTreeListModel, ret, true)
 end
 
+## GtkListBox
+setindex!(lb::GtkListBox, w::GtkWidget, i::Integer) = (G_.insert(lb, w, i - 1); lb[i])
+getindex(lb::GtkListBox, i::Integer) = G_.get_row_at_index(lb, i - 1)
+
+push!(lb::GtkListBox, w::GtkWidget) = (G_.append(lb, w); lb)
+pushfirst!(lb::GtkListBox, w::GtkWidget) = (G_.prepend(lb, w); lb)
+insert!(lb::GtkListBox, i::Integer, w::GtkWidget) = (G_.insert(lb, w, i - 1); lb)
+
+#empty!(lb::GtkListBox) = (ccall(("gtk_list_box_remove_all", libgtk4), Nothing, (Ptr{GObject},), lb); lb)
+
+delete!(lb::GtkListBox, w::GtkWidget) = (G_.remove(lb, w); lb)
+
+function set_filter_func(lb::GtkListBox, match::Function)
+    create_cfunc = @cfunction($match, Cint, (Ptr{GObject}, Ptr{Nothing}))
+    ccall(("gtk_list_box_set_filter_func", libgtk4), Nothing, (Ptr{GObject}, Ptr{Nothing}, Ptr{Nothing}, Ptr{Nothing}), lb, create_cfunc, C_NULL, C_NULL)
+    return nothing
+end
+
+
 ## GtkCustomFilter
 
 function GtkCustomFilter(match::Function)


### PR DESCRIPTION
Hello again! I've added some convenience wrapper functions for the generate GtkListBox functions, as well as the filtering callback and an example. For lists that aren't as dynamic, this option seems easier to use than the ListView + model combination

It's also possible to connect a GtkListBox with a model, but I haven't played around with that yet