### PR TITLE
fix docs

### DIFF
--- a/docs/src/doc/constants_reference.md
+++ b/docs/src/doc/constants_reference.md
@@ -1,0 +1,22 @@
+# Constants
+
+### Gtk4
+
+```@autodocs
+Modules = [Gtk4]
+Order   = [:constant]
+```
+
+### Gtk4.GdkPixbufLib
+
+```@autodocs
+Modules = [Gtk4.GdkPixbufLib]
+Order   = [:constant]
+```
+
+### Gtk4.GLib
+
+```@autodocs
+Modules = [Gtk4.GLib]
+Order   = [:constant]
+```


### PR DESCRIPTION
Get documentation build working again. The CI failure on Windows is unrelated.