### PR TITLE
In callbacks, convert inputs and outputs between pointers and objects

### DIFF
--- a/GI/src/giimport.jl
+++ b/GI/src/giimport.jl
@@ -414,7 +414,13 @@ function decl(callbackinfo::GICallbackInfo)
     args=get_args(callbackinfo)
     rettypeinfo=get_return_type(callbackinfo)
     rettype = extract_type(rettypeinfo)
-    retexpr = (rettype.ctype == :Nothing) ? :(nothing) : :(convert($(rettype.ctype), ret))
+    retexpr = if rettype.ctype == :(Ptr{GObject}) || rettype.ctype == :(Ptr{GVariant}) # not a general solution, but there is not a huge variety of output types
+        :(ret.handle)
+    elseif rettype.ctype == :Nothing
+        :(nothing)
+    else
+        :(convert($(rettype.ctype), ret))
+    end
     
     closure = get_closure(callbackinfo)
     if closure == -1

--- a/docs/src/doc/GLib_reference.md
+++ b/docs/src/doc/GLib_reference.md
@@ -14,6 +14,7 @@ Gtk4.GLib.g_source_remove
 Gtk4.GLib.get_uv_loop_integration
 Gtk4.GLib.set_uv_loop_integration
 Gtk4.GLib.is_uv_loop_integration_enabled
+Gtk4.GLib.run
 ```
 
 ## REPL helper functions
@@ -35,18 +36,21 @@ Gtk4.GLib.signal_argument_types
 Gtk4.GLib.on_notify
 Gtk4.GLib.bind_property
 Gtk4.GLib.unbind_property
+Gtk4.GLib.setproperties!
 ```
 
 ## Signals
 ```@docs
 Gtk4.GLib.signal_handler_is_connected
 Gtk4.GLib.signal_handler_disconnect
+Gtk4.GLib.signal_handler_block
+Gtk4.GLib.signal_handler_unblock
 Gtk4.GLib.waitforsignal
 ```
 
-## Miscellaneous
+## GObject type system
 ```@docs
 Gtk4.GLib.g_type
-Gtk4.GLib.run
+Gtk4.GLib.find_leaf_type
 ```
 

--- a/docs/src/doc/reference.md
+++ b/docs/src/doc/reference.md
@@ -37,6 +37,12 @@ Gtk4.present
 Gtk4.toplevels
 ```
 
+## Input widgets
+
+```@docs
+Gtk4.configure!
+```
+
 ## Dialogs
 ```@docs
 Gtk4.ask_dialog
@@ -46,7 +52,7 @@ Gtk4.open_dialog
 Gtk4.save_dialog
 ```
 
-## GtkCanvas (drawing with Cairo)
+## GtkCanvas (for Cairo drawing)
 
 ```@docs
 Gtk4.GtkCanvas

--- a/docs/src/manual/canvas.md
+++ b/docs/src/manual/canvas.md
@@ -1,7 +1,7 @@
 # Drawing with Cairo
 
 !!! note "Example"
-    The code on this page can be found in "canvas.jl" in the ["examples" subdirectory](https://github.com/JuliaGtk/Gtk4.jl/tree/main/examples).
+    The code below can be found in "canvas.jl" in the ["examples" subdirectory](https://github.com/JuliaGtk/Gtk4.jl/tree/main/examples).
 
 Cairo based drawing can be done on Gtk4.jl's `GtkCanvas` widget, which is based on GTK's `GtkDrawingArea`. The canvas widget comes with a backing store (a Cairo image surface). You control what is drawn on this backing store by defining a `draw` function:
 
@@ -54,7 +54,6 @@ function on_pressed(controller, n_press, x, y)
 end
 
 signal_connect(on_pressed, g, "pressed")
-
 ```
 
 This will draw a green circle on the canvas at every mouse click.
@@ -94,5 +93,5 @@ w = GtkWindow(canvas,"CairoMakie example")
 end
 ```
 
-A more complicated example can be found in the ["examples" subdirectory](https://github.com/JuliaGtk/Gtk4.jl/tree/main/examples).
-For interactive plots, you can try [Gtk4Makie.jl](https://github.com/JuliaGtk/Gtk4Makie.jl), which draws GLMakie plots onto GTK's `GtkGLArea` widget.
+!!! note "Example"
+    A more complicated example can be found in "canvas_cairomakie.jl" in the ["examples" subdirectory](https://github.com/JuliaGtk/Gtk4.jl/tree/main/examples).

--- a/docs/src/manual/listtreeview.md
+++ b/docs/src/manual/listtreeview.md
@@ -87,6 +87,23 @@ signal_connect(entry, :search_changed) do w
 end
 ```
 
+## Sorting
+
+It's also useful to sort the list. This can be done using another model wrapper, `GtkSortListModel`.
+
+Here is an example that sorts the list in reverse alphabetical order:
+```julia
+model = GtkStringList(string.(names(Gtk4)))
+
+ralpha_compare(item1, item2) = isless(item1.string, item2.string) ? 1 : 0
+
+sorter = GtkCustomSorter(match)
+sortedModel = GtkSortListModel(GListModel(model), sorter)
+```
+
+We create a `GtkCustomSorter` using a `compare` callback that takes two arguments `item1` and `item2` and returns -1 if `item1` is before `item2`, 0 if they are equal, and 1 if `item1` is after `item2`. We construct a `GtkSortListModel` using this filter and use it instead of the `GListModel` in the constructor
+for `GtkSingleSelection`.
+
 ## GtkTreeView
 The `GtkTreeView` was the widget used to display table-like or hierarchical data and trees in version 3 of GTK.
 It's also present in version 4 but is being deprecated in the C library in favor of the widgets discussed above.

--- a/docs/src/manual/listtreeview.md
+++ b/docs/src/manual/listtreeview.md
@@ -4,6 +4,10 @@ In version 4, GTK introduced new widgets for efficiently displaying
 table-like data as one-dimensional lists, trees, or two-dimensional arrays.
 
 ## GtkListView
+
+!!! note "Example"
+    The code below can be found in "listview.jl" in the ["examples" subdirectory](https://github.com/JuliaGtk/Gtk4.jl/tree/main/examples).
+
 We start with the widget for displaying one-dimensional lists. Here is a simple example:
 ```julia
 using Gtk4
@@ -56,6 +60,9 @@ Finally, we construct the `GtkListView` using the selection model and the factor
 
 ### Filtering
 
+!!! note "Example"
+    The code below can be found in "filteredlistview.jl" in the ["examples" subdirectory](https://github.com/JuliaGtk/Gtk4.jl/tree/main/examples).
+
 The list above is very long, and it's useful to allow the user to filter it down. An easy way to
 implement this is to use `GtkFilterListModel`, which wraps the model and allows it to be filtered
 before being displayed.
@@ -89,7 +96,10 @@ end
 
 ## Sorting
 
-It's also useful to sort the list. This can be done using another model wrapper, `GtkSortListModel`.
+!!! note "Example"
+    The code below can be found in "sortedlistview.jl" in the ["examples" subdirectory](https://github.com/JuliaGtk/Gtk4.jl/tree/main/examples).
+
+It's also useful to be able to sort the list. This can be done using another model wrapper, `GtkSortListModel`.
 
 Here is an example that sorts the list in reverse alphabetical order:
 ```julia
@@ -103,6 +113,54 @@ sortedModel = GtkSortListModel(GListModel(model), sorter)
 
 We create a `GtkCustomSorter` using a `compare` callback that takes two arguments `item1` and `item2` and returns -1 if `item1` is before `item2`, 0 if they are equal, and 1 if `item1` is after `item2`. We construct a `GtkSortListModel` using this filter and use it instead of the `GListModel` in the constructor
 for `GtkSingleSelection`.
+
+## GtkColumnView
+
+What if we want to display information in columns? Let's say we want to have one column show the name of the function and another show the number of methods. For this we can use `GtkColumnView`. It works very similarly to `GtkListView`, but instead of having one factory for the entire widget, each column has a factory whose `setup` and `bind` callbacks populate the widgets used to display the information for that column.
+
+Here is an example:
+```julia
+using Gtk4
+
+win = GtkWindow("ColumnView demo", 450, 800)
+sw = GtkScrolledWindow()
+push!(win, sw)
+
+model = GtkStringList(string.(names(Gtk4)))
+
+function setup_cb(f, li)
+    set_child(li,GtkLabel(""))
+end
+
+function bind_cb(f, li)
+    text = li[].string
+    label = get_child(li)
+    label.label = text
+end
+
+function bind2_cb(f, li)
+    text = li[].string
+    label = get_child(li)
+    label.label = string(length(methods(eval(Symbol(text)))))
+end
+
+list = GtkColumnView(GtkSelectionModel(GtkSingleSelection(GListModel(model))))
+
+factory1 = GtkSignalListItemFactory(setup_cb, bind_cb)
+col1 = GtkColumnViewColumn("name", factory1)
+push!(list, col1)
+
+factory2 = GtkSignalListItemFactory(setup_cb, bind2_cb)
+col2 = GtkColumnViewColumn("methods", factory2)
+push!(list, col2)
+
+sw[] = list
+```
+
+Note that filtering and sorting work just the same as with `GtkListView` since they operate on the model.
+
+!!! note "Example"
+    An example of using `GtkColumnView` with filtering and sorting can be found in "columnview.jl" in the ["examples" subdirectory](https://github.com/JuliaGtk/Gtk4.jl/tree/main/examples).
 
 ## GtkTreeView
 The `GtkTreeView` was the widget used to display table-like or hierarchical data and trees in version 3 of GTK.

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@
 - `listview.jl` demonstrates using `GtkListView` to show a huge list of strings.
 - `filteredlistview.jl` demonstrates `GtkListView` with a `GtkSearchEntry` to filter what's shown.
 - `sortedlistview.jl` demonstrates `GtkListView` with a `GtkDropDown` widget to control how the list is sorted.
+- `columnview.jl` demonstrates using `GtkColumnView` to show lists with multiple columns.
 - `listbox.jl` demonstrates `GtkListBox` to show a huge list of strings. This widget is a little easier to use than `GtkListView` but may be less performant.
 
 ## Applications

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,9 +11,10 @@
 - `glarea.jl` shows how to use the `GtkGLArea` widget to draw using OpenGL.
 
 ## Lists
-- `filteredlistview.jl` demonstrates `GtkListView` to show a huge list of strings, with a `GtkSearchEntry` to filter what's shown.
-- `listbox.jl` demonstrates `GtkListBox` to show a huge list of strings. This widget is a little easier to use than `GtkListView`.
-- `listview.jl` demonstrates a simple way of using `GtkListView`.
+- `listview.jl` demonstrates using `GtkListView` to show a huge list of strings.
+- `filteredlistview.jl` demonstrates `GtkListView` with a `GtkSearchEntry` to filter what's shown.
+- `sortedlistview.jl` demonstrates `GtkListView` with a `GtkDropDown` widget to control how the list is sorted.
+- `listbox.jl` demonstrates `GtkListBox` to show a huge list of strings. This widget is a little easier to use than `GtkListView` but may be less performant.
 
 ## Applications
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,9 +12,10 @@
 
 ## Lists
 - `listview.jl` demonstrates using `GtkListView` to show a huge list of strings.
-- `filteredlistview.jl` demonstrates `GtkListView` with a `GtkSearchEntry` to filter what's shown.
+- `filteredlistview.jl` demonstrates `GtkListView` with a `GtkSearchEntry` and `GtkCustomFilter` to filter what's shown.
 - `sortedlistview.jl` demonstrates `GtkListView` with a `GtkDropDown` widget to control how the list is sorted.
 - `columnview.jl` demonstrates using `GtkColumnView` to show lists with multiple columns.
+- `filteredlistview_tree.jl` demonstrates using `GtkListView` to show a tree. Uses `GtkCustomFilter` to filter what's shown.
 - `listbox.jl` demonstrates `GtkListBox` to show a huge list of strings. This widget is a little easier to use than `GtkListView` but may be less performant.
 
 ## Applications

--- a/examples/columnview.jl
+++ b/examples/columnview.jl
@@ -56,11 +56,11 @@ end
 
 # Filtering
 
-filter = GtkCustomFilter(match)
-filteredModel = GtkFilterListModel(GListModel(sortedModel), filter)
+filt = GtkCustomFilter(match)
+filteredModel = GtkFilterListModel(GListModel(sortedModel), filt)
 
 signal_connect(entry, :search_changed) do w
-  @idle_add changed(filter, Gtk4.FilterChange_DIFFERENT) 
+  @idle_add changed(filt, Gtk4.FilterChange_DIFFERENT)
 end
 
 # Create ColumnView

--- a/examples/columnview.jl
+++ b/examples/columnview.jl
@@ -1,0 +1,94 @@
+using Gtk4
+
+# Column view with filtering and sorting
+
+win = GtkWindow("ColumnView demo", 450, 800)
+bx = GtkBox(:v)
+sw = GtkScrolledWindow()
+push!(win, bx)
+hbx = GtkBox(:h)
+entry = GtkSearchEntry()
+push!(hbx, entry)
+sort_control = GtkDropDown(["Alphabetical","Reverse alphabetical","# methods (most to least)"])
+push!(hbx, sort_control)
+push!(bx, hbx)
+push!(bx, sw)
+
+# The model
+
+model = GtkStringList(string.(names(Gtk4)))
+
+# Sorting
+
+# define sorting functions (should return -1 if item1 is before item2, 0 if they are equal, and 1 if item1 is after item2
+alpha_compare(item1, item2) = isless(item1.string, item2.string) ? -1 : 1   # alphabetical
+ralpha_compare(item1, item2) = -alpha_compare(item1, item2)                 # reverse alphabetical
+function methods_compare(item1, item2)
+    n1 = length(methods(eval(Symbol(item1.string))))
+    n2 = length(methods(eval(Symbol(item2.string))))
+    if n1 == n2
+        return 0
+    end
+    isless(n1,n2) ? 1 : -1
+end
+
+signal_connect(sort_control, "notify::selected") do w, others...
+  sel = Gtk4.selected_string(w)
+  c = if sel == "Alphabetical"
+      alpha_compare
+  elseif sel == "Reverse alphabetical"
+      ralpha_compare
+  elseif sel == "# methods (most to least)"
+      methods_compare
+  end
+  @idle_add begin
+      Gtk4.set_sort_func(sorter, c)
+      changed(sorter)
+  end
+end
+
+sorter = GtkCustomSorter(alpha_compare)
+sortedModel = GtkSortListModel(GListModel(model), sorter)
+
+function match(item)
+  return startswith(item.string, entry.text)
+end
+
+# Filtering
+
+filter = GtkCustomFilter(match)
+filteredModel = GtkFilterListModel(GListModel(sortedModel), filter)
+
+signal_connect(entry, :search_changed) do w
+  @idle_add changed(filter, Gtk4.FilterChange_DIFFERENT) 
+end
+
+# Create ColumnView
+
+function setup_cb(f, li)
+    set_child(li,GtkLabel(""))
+end
+
+function bind_cb(f, li)
+    text = li[].string
+    label = get_child(li)
+    label.label = text
+end
+
+function bind2_cb(f, li)
+    text = li[].string
+    label = get_child(li)
+    label.label = string(length(methods(eval(Symbol(text)))))
+end
+
+list = GtkColumnView(GtkSelectionModel(GtkSingleSelection(GListModel(filteredModel))); vexpand=true)
+factory1 = GtkSignalListItemFactory(setup_cb, bind_cb)
+col1 = GtkColumnViewColumn("name", factory1)
+push!(list, col1)
+
+factory2 = GtkSignalListItemFactory(setup_cb, bind2_cb)
+col2 = GtkColumnViewColumn("methods", factory2)
+push!(list, col2)
+
+sw[] = list
+

--- a/examples/filteredlistview.jl
+++ b/examples/filteredlistview.jl
@@ -27,14 +27,14 @@ function match(item)
   return startswith(item.string, entry.text)
 end
 
-filter = GtkCustomFilter(match)
-filteredModel = GtkFilterListModel(GListModel(model), filter)
+filt = GtkCustomFilter(match)
+filteredModel = GtkFilterListModel(GListModel(model), filt)
 
 list = GtkListView(GtkSelectionModel(GtkSingleSelection(GListModel(filteredModel))), factory)
 list.vexpand = true
 
 signal_connect(entry, :search_changed) do w
-  @idle_add changed(filter, Gtk4.FilterChange_DIFFERENT) 
+  @idle_add changed(filt, Gtk4.FilterChange_DIFFERENT)
 end
 
 sw[] = list

--- a/examples/filteredlistview.jl
+++ b/examples/filteredlistview.jl
@@ -1,4 +1,4 @@
-using Gtk4, Gtk4.GLib
+using Gtk4
 
 win = GtkWindow("Listview demo with filter")
 box = GtkBox(:v)
@@ -23,21 +23,18 @@ end
 
 factory = GtkSignalListItemFactory(setup_cb, bind_cb)
 
-function match(list_item)
-  itemLeaf = Gtk4.GLib.find_leaf_type(list_item)
-  item = convert(itemLeaf, list_item)
-  result = startswith(item.string, entry.text)
-  return result ? Cint(1) : Cint(0)
+function match(item)
+  return startswith(item.string, entry.text)
 end
 
 filter = GtkCustomFilter(match)
-filteredModel = GtkFilterListModel(GLib.GListModel(model), filter)
+filteredModel = GtkFilterListModel(GListModel(model), filter)
 
-list = GtkListView(GtkSelectionModel(GtkSingleSelection(GLib.GListModel(filteredModel))), factory)
+list = GtkListView(GtkSelectionModel(GtkSingleSelection(GListModel(filteredModel))), factory)
 list.vexpand = true
 
 signal_connect(entry, :search_changed) do w
-  @idle_add Gtk4.G_.changed(filter, Gtk4.FilterChange_DIFFERENT) 
+  @idle_add changed(filter, Gtk4.FilterChange_DIFFERENT) 
 end
 
 sw[] = list

--- a/examples/filteredlistview_tree.jl
+++ b/examples/filteredlistview_tree.jl
@@ -1,0 +1,105 @@
+using Gtk4, Gtk4.GLib
+
+const entry = GtkSearchEntry()
+
+# create root model (list of modules)
+const modules = filter(x->!endswith(x.first.name, "_jll"),Base.loaded_modules)
+const model = GtkStringList(string.(names(Gtk4)))
+
+# create tree model (names under modules)
+rootmodel = GtkStringList([x.first.name for x in modules])
+
+const ks = collect(keys(modules))
+
+function create_model(obj)
+    if obj.string in [x.first.name for x in modules]
+        mod = modules[ks[findfirst(x->x.name == obj.string, ks)]]
+        modnames = [join([obj.string, string(n)], ".") for n in names(mod)]
+        modelValues = GtkStringList(modnames)
+        GLib.glib_ref(modelValues)
+        return modelValues.handle
+    else
+        return C_NULL
+    end
+end
+
+const treemodel = GtkTreeListModel(GListModel(rootmodel),false, true, create_model)
+
+# create factory for list view
+function get_funcname(text)  # faster than split(text,'.')[end]
+    i=findfirst('.',text)
+    if i !== nothing
+        return @views text[(i+1):end]
+    end
+    return text
+end
+
+function setup_cb(f, li)
+    tree_expander = GtkTreeExpander()
+    set_child(tree_expander,GtkLabel(""))
+    set_child(li,tree_expander)
+end
+
+function bind_cb(f, li)
+    row = li[]
+    tree_expander = get_child(li)
+    Gtk4.set_list_row(tree_expander, row)
+    text = Gtk4.G_.get_string(Gtk4.get_item(row))
+    label = get_child(tree_expander)
+    Gtk4.label(label, get_funcname(text))
+end
+
+factory = GtkSignalListItemFactory(setup_cb, bind_cb)
+
+# set up filtering
+function matchstr(str, ent)
+    i=findfirst('.',str)
+    if i !== nothing
+        sstr = @views str[(i+1):end]
+        return startswith(sstr, ent)
+    else
+        return startswith(str, ent)
+    end
+end
+matchstr(str, ::Nothing) = true
+matchchildren(cren, ent) = any(x->matchstr(x, ent), cren)
+
+function match(row::GtkTreeListRow)
+    entrytext = Gtk4.text(GtkEditable(entry))
+    if entrytext == "" || entrytext === nothing
+        return true
+    end
+    item = Gtk4.get_item(row)
+    if item === nothing
+        return false
+    end
+    text = Gtk4.G_.get_string(item)
+    thismatch = matchstr(text, entrytext)
+    if thismatch
+        return true
+    end
+    cren = Gtk4.get_children(row)
+    if cren !== nothing && !thismatch  # check children
+        return matchchildren(cren, entrytext)  # return true if any children match
+    end
+    return false
+end
+
+filt = GtkCustomFilter(match)
+filteredModel = GtkFilterListModel(GListModel(treemodel), filt)
+
+# create listview
+selmodel = GtkSelectionModel(GtkSingleSelection(GListModel(filteredModel)))
+list = GtkListView(selmodel, factory; vexpand=true)
+
+# connect to filter
+signal_connect(entry, :search_changed) do w
+  @idle_add changed(filt, Gtk4.FilterChange_DIFFERENT) 
+end
+
+win = GtkWindow("Listview tree demo with filter",600,800)
+win[] = box = GtkBox(:v)
+push!(box, entry)
+sw = GtkScrolledWindow()
+push!(box, sw)
+sw[] = list

--- a/examples/filteredlistview_tree.jl
+++ b/examples/filteredlistview_tree.jl
@@ -1,15 +1,15 @@
 using Gtk4, Gtk4.GLib
 
-const entry = GtkSearchEntry()
+const searchentry = GtkSearchEntry()
 
 # create root model (list of modules)
-const modules = filter(x->!endswith(x.first.name, "_jll"),Base.loaded_modules)
-const model = GtkStringList(string.(names(Gtk4)))
+modules = filter(x->!endswith(x.first.name, "_jll"),Base.loaded_modules)
+model = GtkStringList(string.(names(Gtk4)))
 
 # create tree model (names under modules)
 rootmodel = GtkStringList([x.first.name for x in modules])
 
-const ks = collect(keys(modules))
+ks = collect(keys(modules))
 
 function create_model(obj)
     if obj.string in [x.first.name for x in modules]
@@ -23,7 +23,7 @@ function create_model(obj)
     end
 end
 
-const treemodel = GtkTreeListModel(GListModel(rootmodel),false, true, create_model)
+treemodel = GtkTreeListModel(GListModel(rootmodel),false, true, create_model)
 
 # create factory for list view
 function get_funcname(text)  # faster than split(text,'.')[end]
@@ -65,7 +65,7 @@ matchstr(str, ::Nothing) = true
 matchchildren(cren, ent) = any(x->matchstr(x, ent), cren)
 
 function match(row::GtkTreeListRow)
-    entrytext = Gtk4.text(GtkEditable(entry))
+    entrytext = Gtk4.text(GtkEditable(searchentry))
     if entrytext == "" || entrytext === nothing
         return true
     end
@@ -93,13 +93,13 @@ selmodel = GtkSelectionModel(GtkSingleSelection(GListModel(filteredModel)))
 list = GtkListView(selmodel, factory; vexpand=true)
 
 # connect to filter
-signal_connect(entry, :search_changed) do w
+signal_connect(searchentry, :search_changed) do w
   @idle_add changed(filt, Gtk4.FilterChange_DIFFERENT) 
 end
 
 win = GtkWindow("Listview tree demo with filter",600,800)
 win[] = box = GtkBox(:v)
-push!(box, entry)
+push!(box, searchentry)
 sw = GtkScrolledWindow()
 push!(box, sw)
 sw[] = list

--- a/examples/filteredlistview_tree.jl
+++ b/examples/filteredlistview_tree.jl
@@ -16,10 +16,9 @@ function create_model(obj)
         mod = modules[ks[findfirst(x->x.name == obj.string, ks)]]
         modnames = [join([obj.string, string(n)], ".") for n in names(mod)]
         modelValues = GtkStringList(modnames)
-        GLib.glib_ref(modelValues)
-        return modelValues.handle
+        return modelValues
     else
-        return C_NULL
+        return nothing
     end
 end
 

--- a/examples/glarea.jl
+++ b/examples/glarea.jl
@@ -178,7 +178,6 @@ function on_realized(a)
 	vertexShader = createShader(vsh, GL_VERTEX_SHADER)
 	fragmentShader = createShader(fsh, GL_FRAGMENT_SHADER)
 	state.program = createShaderProgram(vertexShader, fragmentShader)
-	@async println(state.program)
 end
 
 function render(a, c, user_data)

--- a/examples/listbox.jl
+++ b/examples/listbox.jl
@@ -11,17 +11,15 @@ push!(win, box)
 listBox = GtkListBox()
 foreach(x-> push!(listBox, GtkLabel(x)), string.(names(Gtk4)))
 
-function match(ptr)
-  row = convert(GtkListBoxRowLeaf, ptr)
+function match(row)
   label = row.child
-  result = startswith(label.label, entry.text)
-  return result ? Cint(1) : Cint(0)
+  return startswith(label.label, entry.text)
 end
 
 Gtk4.set_filter_func(listBox, match)
 
 signal_connect(entry, :search_changed) do w
-  @idle_add Gtk4.G_.invalidate_filter(listBox) 
+  @idle_add Gtk4.G_.invalidate_filter(listBox)
 end
 
 sw[] = listBox

--- a/examples/listview.jl
+++ b/examples/listview.jl
@@ -1,6 +1,6 @@
-using Gtk4, Gtk4.GLib
+using Gtk4
 
-win = GtkWindow("Listview demo")
+win = GtkWindow("Listview demo", 250, 800)
 sw = GtkScrolledWindow()
 push!(win, sw)
 
@@ -17,6 +17,6 @@ function bind_cb(f, li)
 end
 
 factory = GtkSignalListItemFactory(setup_cb, bind_cb)
-list = GtkListView(GtkSelectionModel(GtkSingleSelection(GLib.GListModel(model))), factory)
+list = GtkListView(GtkSelectionModel(GtkSingleSelection(GListModel(model))), factory)
 
 sw[] = list

--- a/examples/sortedlistview.jl
+++ b/examples/sortedlistview.jl
@@ -1,0 +1,59 @@
+using Gtk4
+
+win = GtkWindow("Listview demo with sort", 300, 800)
+box = GtkBox(:v)
+sort_control = GtkDropDown(["Alphabetical","Reverse alphabetical","# methods (most to least)"])
+sw = GtkScrolledWindow()
+push!(box, sort_control)
+push!(box, sw)
+push!(win, box)
+
+modelValues = string.(names(Gtk4))
+model = GtkStringList(modelValues)
+
+function setup_cb(f, li)
+    set_child(li,GtkLabel(""))
+end
+
+function bind_cb(f, li)
+    text = li[].string
+    label = get_child(li)
+    label.label = text
+end
+
+factory = GtkSignalListItemFactory(setup_cb, bind_cb)
+
+# define sorting functions (should return -1 if item1 is before item2, 0 if they are equal, and 1 if item1 is after item2
+alpha_compare(item1, item2) = isless(item1.string, item2.string) ? -1 : 1   # alphabetical
+ralpha_compare(item1, item2) = -alpha_compare(item1, item2)                 # reverse alphabetical
+function methods_compare(item1, item2)
+    n1 = length(methods(eval(Symbol(item1.string))))
+    n2 = length(methods(eval(Symbol(item2.string))))
+    if n1 == n2
+        return 0
+    end
+    isless(n1,n2) ? 1 : -1
+end
+
+sorter = GtkCustomSorter(alpha_compare)
+sortedModel = GtkSortListModel(GListModel(model), sorter)
+
+list = GtkListView(GtkSelectionModel(GtkSingleSelection(GListModel(sortedModel))), factory)
+list.vexpand = true
+
+signal_connect(sort_control, "notify::selected") do w, others...
+  sel = Gtk4.selected_string(w)
+  c = if sel == "Alphabetical"
+      alpha_compare
+  elseif sel == "Reverse alphabetical"
+      ralpha_compare
+  elseif sel == "# methods (most to least)"
+      methods_compare
+  end
+  @idle_add begin
+      Gtk4.set_sort_func(sorter, c)
+      changed(sorter)
+  end
+end
+
+sw[] = list

--- a/gen/gen_gdk4.jl
+++ b/gen/gen_gdk4.jl
@@ -68,35 +68,6 @@ GI.all_interface_methods!(exprs,ns;skiplist=skiplist)
 
 GI.write_to_file(path,"gdk4_methods",toplevel)
 
-## object properties
-
-for o in GI.get_all(ns,GI.GIObjectInfo)
-    name=GI.get_name(o)
-    println("object: $name")
-    properties=GI.get_properties(o)
-    for p in properties
-        flags=GI.get_flags(p)
-        tran=GI.get_ownership_transfer(p)
-        println("property: ",GI.get_name(p)," ",tran)
-        if GI.is_deprecated(p)
-            continue
-        end
-        typ=GI.get_type(p)
-        btyp=GI.get_base_type(typ)
-        println(GI.get_name(p)," ",btyp)
-        #try
-            #fun=GI.create_method(m,GI.get_c_prefix(ns))
-            #push!(exprs, fun)
-            #global created+=1
-        #catch NotImplementedError
-        #    global not_implemented+=1
-        #catch LoadError
-        #    println("error")
-        #end
-    end
-end
-
-
 ## functions
 
 toplevel, exprs, exports = GI.output_exprs()

--- a/gen/gen_gdkpixbuf.jl
+++ b/gen/gen_gdkpixbuf.jl
@@ -44,7 +44,7 @@ GI.append_struc_docs!(exprs, "gdk-pixbuf", d, c, ns)
 c = GI.all_objects!(exprs,exports,ns;constructor_skiplist=[:new_from_resource,:new_with_mime_type,:new_from_resource_at_scale])
 GI.append_object_docs!(exprs, "gdk-pixbuf", d, c, ns)
 GI.all_callbacks!(exprs, exports, ns)
-GI.all_object_signals!(exprs,ns;skiplist=skiplist)
+GI.all_object_signals!(exprs,ns)
 push!(exprs,exports)
 
 GI.write_to_file(path,"gdkpixbuf_structs",toplevel)

--- a/gen/gen_gsk.jl
+++ b/gen/gen_gsk.jl
@@ -60,35 +60,6 @@ GI.all_interface_methods!(exprs,ns)
 
 GI.write_to_file(path,"gsk4_methods",toplevel)
 
-## object properties
-
-for o in GI.get_all(ns,GI.GIObjectInfo)
-    name=GI.get_name(o)
-    println("object: $name")
-    properties=GI.get_properties(o)
-    for p in properties
-        flags=GI.get_flags(p)
-        tran=GI.get_ownership_transfer(p)
-        println("property: ",GI.get_name(p)," ",tran)
-        if GI.is_deprecated(p)
-            continue
-        end
-        typ=GI.get_type(p)
-        btyp=GI.get_base_type(typ)
-        println(GI.get_name(p)," ",btyp)
-        #try
-            #fun=GI.create_method(m,GI.get_c_prefix(ns))
-            #push!(exprs, fun)
-            #global created+=1
-        #catch NotImplementedError
-        #    global not_implemented+=1
-        #catch LoadError
-        #    println("error")
-        #end
-    end
-end
-
-
 ## functions
 
 toplevel, exprs, exports = GI.output_exprs()

--- a/src/GLib/GLib.jl
+++ b/src/GLib/GLib.jl
@@ -189,6 +189,11 @@ eval(include("../gen/gio_functions"))
 
 end
 
+get_pointer(x::Ptr) = x
+get_pointer(x::GObject) = x.handle
+get_pointer(x::GVariant) = x.handle
+get_pointer(::Nothing) = C_NULL
+
 include("gobject.jl")
 include("listmodel.jl")
 include("loop.jl")

--- a/src/GLib/gobject.jl
+++ b/src/GLib/gobject.jl
@@ -1,3 +1,9 @@
+"""
+    setproperties!(obj::GObject; kwargs...)
+
+Set many `GObject` properties at once using keyword arguments. For example
+for a `GtkWindow`, `setproperties!(win; title="New title", visible=true)`.
+"""
 function setproperties!(obj::GObject; kwargs...)
     for (kw, val) = kwargs
         set_gtk_property!(obj, kw, val)

--- a/src/GLib/gtype.jl
+++ b/src/GLib/gtype.jl
@@ -234,6 +234,7 @@ function glib_ref(x::GObject)
     glib_ref(x.handle)
     x
 end
+glib_ref(::Nothing) = nothing
 gc_unref(p::Ptr{GObject}) = glib_unref(p)
 function glib_unref(x::Ptr{GObject})
     ccall((:g_object_unref, libgobject), Nothing, (Ptr{GObject},), x)

--- a/src/GLib/gtype.jl
+++ b/src/GLib/gtype.jl
@@ -163,6 +163,17 @@ function convert_(::Type{T}, ptr::Ptr{T}, owns=false) where T <: GObject
     ret
 end
 
+"""
+    find_leaf_type(hnd::Ptr{T}) where T <: GObject
+
+For a pointer to a `GObject`, look up its type in the `GType` system and return
+the Julia leaf type that best matches it. For types supported by Gtk4, for
+example `GtkWindow`, this will be the leaf type `GtkWindowLeaf`. Some types
+defined in GTK4 and other libraries are not exported. In this case, the nearest
+parent type supported by the Julia package will be returned. For example,
+objects in GIO that implement the GFile interface are returned as
+`GObjectLeaf`.
+"""
 function find_leaf_type(hnd::Ptr{T}) where T <: GObject
     gtyp = G_OBJECT_CLASS_TYPE(hnd)
     typname = g_type_name(gtyp)

--- a/src/Gtk4.jl
+++ b/src/Gtk4.jl
@@ -65,7 +65,8 @@ end
 end
 
 import .GLib: set_gtk_property!, get_gtk_property, run,
-              signal_handler_is_connected, signalnames
+              signal_handler_is_connected, signalnames,
+              GListModel
 
 # define accessor methods in Gtk4
 

--- a/src/basic_exports.jl
+++ b/src/basic_exports.jl
@@ -24,6 +24,8 @@ export info_dialog, ask_dialog, warn_dialog, error_dialog, input_dialog
 export color_dialog
 export response
 
+export GListModel, changed
+
 # GLib-imported event handling
 export signal_connect, signal_handler_disconnect,
     signal_handler_block, signal_handler_unblock, signal_handler_is_connected,

--- a/src/displays.jl
+++ b/src/displays.jl
@@ -45,7 +45,7 @@ stop(spinner::GtkSpinner) = G_.stop(spinner)
 
 context_id(status::GtkStatusbar, source) = G_.get_context_id(status, source)
 context_id(status::GtkStatusbar, source::Integer) = source
-push!(status::GtkStatusbar, context, text) =
+push!(status::GtkStatusbar, context::Union{Integer,AbstractString}, text::AbstractString) =
     (G_.push(status, context_id(status, context), text); status)
 pop!(status::GtkStatusbar, context) = G_.pop(status, context_id(status, context))
 #splice!(status::GtkStatusbar, context, message_id) =

--- a/src/gen/gdkpixbuf_methods
+++ b/src/gen/gdkpixbuf_methods
@@ -162,7 +162,7 @@ $(Expr(:toplevel, quote
         m_width = Ref{Int32}()
         m_height = Ref{Int32}()
         ret = ccall(("gdk_pixbuf_get_file_info", libgdkpixbuf), Ptr{_GdkPixbufFormat}, (Cstring, Ptr{Int32}, Ptr{Int32}), _filename, m_width, m_height)
-        ret2 = convert_if_not_null(Union{GdkPixbufFormat, Ref{_GdkPixbufFormat}}, ret, false)
+        ret2 = convert_if_not_null(GdkPixbufFormat, ret, false)
         _width = m_width[]
         _height = m_height[]
         (ret2, _width, _height)
@@ -510,7 +510,7 @@ $(Expr(:toplevel, quote
     end
     function get_format(instance::GdkPixbufLoader)
         ret = ccall(("gdk_pixbuf_loader_get_format", libgdkpixbuf), Ptr{_GdkPixbufFormat}, (Ptr{GObject},), instance)
-        ret2 = convert_if_not_null(Union{GdkPixbufFormat, Ref{_GdkPixbufFormat}}, ret, false)
+        ret2 = convert_if_not_null(GdkPixbufFormat, ret, false)
         ret2
     end
     function get_pixbuf(instance::GdkPixbufLoader)

--- a/src/gen/gdkpixbuf_structs
+++ b/src/gen/gdkpixbuf_structs
@@ -309,21 +309,27 @@ $(Expr(:toplevel, quote
         convert(Ptr{GObject}, ret)
     end
     function GdkPixbufModulePreparedFunc(pixbuf, anim, user_data)
+        pixbuf = convert(GdkPixbuf, pixbuf, false)
+        anim = convert(GdkPixbufAnimation, anim, false)
         f = user_data
         ret = f(pixbuf, anim)
         nothing
     end
     function GdkPixbufModuleSizeFunc(width, height, user_data)
+        width = convert(Int32, width)
+        height = convert(Int32, height)
         f = user_data
         ret = f(width, height)
         nothing
     end
     function GdkPixbufModuleUpdatedFunc(pixbuf, x, y, width, height, user_data)
+        pixbuf = convert(GdkPixbuf, pixbuf, false)
         f = user_data
         ret = f(pixbuf, x, y, width, height)
         nothing
     end
     function GdkPixbufSaveFunc(buf, count, error, data)
+        buf = collect(unsafe_wrap(Vector{UInt8}, buf, m_count[]))
         f = data
         ret = f(buf, count, error)
         convert(Cint, ret)

--- a/src/gen/gdkpixbuf_structs
+++ b/src/gen/gdkpixbuf_structs
@@ -306,7 +306,7 @@ $(Expr(:toplevel, quote
     function GdkPixbufModuleLoadXpmDataFunc(data)
         f = data
         ret = f()
-        convert(Ptr{GObject}, ret)
+        ret.handle
     end
     function GdkPixbufModulePreparedFunc(pixbuf, anim, user_data)
         pixbuf = convert(GdkPixbuf, pixbuf, false)

--- a/src/gen/gdkpixbuf_structs
+++ b/src/gen/gdkpixbuf_structs
@@ -306,7 +306,10 @@ $(Expr(:toplevel, quote
     function GdkPixbufModuleLoadXpmDataFunc(data)
         f = data
         ret = f()
-        ret.handle
+        begin
+            GLib.glib_ref(ret)
+            convert(Ptr{GObject}, GLib.get_pointer(ret))
+        end
     end
     function GdkPixbufModulePreparedFunc(pixbuf, anim, user_data)
         pixbuf = convert(GdkPixbuf, pixbuf, false)

--- a/src/gen/gio_methods
+++ b/src/gen/gio_methods
@@ -4686,7 +4686,7 @@ $(Expr(:toplevel, quote
         check_err(err)
         ret2 = convert(GSocketConnection, ret, true)
         _source_object = m_source_object[]
-        _source_object = convert_if_not_null(Maybe(GObject), _source_object, false)
+        _source_object = convert_if_not_null(GObject, _source_object, false)
         (ret2, _source_object)
     end
     function accept_async(instance::GSocketListener, _cancellable::Maybe(GCancellable), _callback::Maybe(Function))
@@ -4708,7 +4708,7 @@ $(Expr(:toplevel, quote
         check_err(err)
         ret2 = convert(GSocketConnection, ret, true)
         _source_object = m_source_object[]
-        _source_object = convert_if_not_null(Maybe(GObject), _source_object, false)
+        _source_object = convert_if_not_null(GObject, _source_object, false)
         (ret2, _source_object)
     end
     function accept_socket(instance::GSocketListener, _cancellable::Maybe(GCancellable))
@@ -4719,7 +4719,7 @@ $(Expr(:toplevel, quote
         check_err(err)
         ret2 = convert(GSocket, ret, true)
         _source_object = m_source_object[]
-        _source_object = convert_if_not_null(Maybe(GObject), _source_object, false)
+        _source_object = convert_if_not_null(GObject, _source_object, false)
         (ret2, _source_object)
     end
     function accept_socket_async(instance::GSocketListener, _cancellable::Maybe(GCancellable), _callback::Maybe(Function))
@@ -4741,7 +4741,7 @@ $(Expr(:toplevel, quote
         check_err(err)
         ret2 = convert(GSocket, ret, true)
         _source_object = m_source_object[]
-        _source_object = convert_if_not_null(Maybe(GObject), _source_object, false)
+        _source_object = convert_if_not_null(GObject, _source_object, false)
         (ret2, _source_object)
     end
     function add_address(instance::GSocketListener, _address::GSocketAddress, _type, _protocol, _source_object::Maybe(GObject))
@@ -4821,9 +4821,9 @@ $(Expr(:toplevel, quote
         check_err(err)
         ret2 = convert(Bool, ret)
         _stdout_buf = m_stdout_buf[]
-        _stdout_buf = convert_if_not_null(Maybe(GBytes), _stdout_buf, true)
+        _stdout_buf = convert_if_not_null(GBytes, _stdout_buf, true)
         _stderr_buf = m_stderr_buf[]
-        _stderr_buf = convert_if_not_null(Maybe(GBytes), _stderr_buf, true)
+        _stderr_buf = convert_if_not_null(GBytes, _stderr_buf, true)
         (ret2, _stdout_buf, _stderr_buf)
     end
     function communicate_async(instance::GSubprocess, _stdin_buf::Maybe(GBytes), _cancellable::Maybe(GCancellable), _callback::Maybe(Function))
@@ -4847,9 +4847,9 @@ $(Expr(:toplevel, quote
         check_err(err)
         ret2 = convert(Bool, ret)
         _stdout_buf = m_stdout_buf[]
-        _stdout_buf = convert_if_not_null(Maybe(GBytes), _stdout_buf, true)
+        _stdout_buf = convert_if_not_null(GBytes, _stdout_buf, true)
         _stderr_buf = m_stderr_buf[]
-        _stderr_buf = convert_if_not_null(Maybe(GBytes), _stderr_buf, true)
+        _stderr_buf = convert_if_not_null(GBytes, _stderr_buf, true)
         (ret2, _stdout_buf, _stderr_buf)
     end
     function communicate_utf8(instance::GSubprocess, _stdin_buf::Maybe(Union{AbstractString, Symbol}), _cancellable::Maybe(GCancellable))

--- a/src/gen/gio_structs
+++ b/src/gen/gio_structs
@@ -3663,7 +3663,10 @@ $(Expr(:toplevel, quote
         property_name = string_or_nothing(property_name, false)
         f = user_data
         ret = f(connection, sender, object_path, interface_name, property_name, error)
-        ret.handle
+        begin
+            GLib.glib_ref(ret)
+            convert(Ptr{GVariant}, GLib.get_pointer(ret))
+        end
     end
     function GDBusInterfaceMethodCallFunc(connection, sender, object_path, interface_name, method_name, parameters, invocation, user_data)
         connection = convert(GDBusConnection, connection, false)
@@ -3694,7 +3697,10 @@ $(Expr(:toplevel, quote
         incoming = convert(Bool, incoming)
         f = user_data
         ret = f(connection, message, incoming)
-        ret.handle
+        begin
+            GLib.glib_ref(ret)
+            convert(Ptr{GObject}, GLib.get_pointer(ret))
+        end
     end
     function GDBusProxyTypeFunc(manager, object_path, interface_name, data)
         manager = convert(GDBusObjectManagerClient, manager, false)
@@ -3801,7 +3807,10 @@ $(Expr(:toplevel, quote
         expected_type = convert(GVariantType, expected_type, false)
         f = user_data
         ret = f(value, expected_type)
-        ret.handle
+        begin
+            GLib.glib_ref(ret)
+            convert(Ptr{GVariant}, GLib.get_pointer(ret))
+        end
     end
     function GSettingsGetMapping(value, result, user_data)
         value = convert(GVariant, value)
@@ -3822,7 +3831,10 @@ $(Expr(:toplevel, quote
         identifier = string_or_nothing(identifier, false)
         f = user_data
         ret = f(vfs, identifier)
-        ret.handle
+        begin
+            GLib.glib_ref(ret)
+            convert(Ptr{GObject}, GLib.get_pointer(ret))
+        end
     end
     function on_launch_failed(f, object::GAppLaunchContext, user_data = object, after = false)
         GLib.signal_connect_generic(f, object, "launch-failed", Nothing, (Cstring,), after, user_data)

--- a/src/gen/gio_structs
+++ b/src/gen/gio_structs
@@ -3604,96 +3604,163 @@ $(Expr(:toplevel, quote
     @doc "See the [GTK docs](https://docs.gtk.org/gio/class.ZlibCompressor.html)." GZlibCompressor
     @doc "See the [GTK docs](https://docs.gtk.org/gio/class.ZlibDecompressor.html)." GZlibDecompressor
     function GAsyncReadyCallback(source_object, res, data)
+        source_object = convert_if_not_null(GObject, source_object, false)
+        res = begin
+                leaftype = GLib.find_leaf_type(res)
+                convert(leaftype, res, false)
+            end
         f = data
         ret = f(source_object, res)
         nothing
     end
     function GBusAcquiredCallback(connection, name, user_data)
+        connection = convert(GDBusConnection, connection, false)
+        name = string_or_nothing(name, false)
         f = user_data
         ret = f(connection, name)
         nothing
     end
     function GBusNameAcquiredCallback(connection, name, user_data)
+        connection = convert(GDBusConnection, connection, false)
+        name = string_or_nothing(name, false)
         f = user_data
         ret = f(connection, name)
         nothing
     end
     function GBusNameAppearedCallback(connection, name, name_owner, user_data)
+        connection = convert(GDBusConnection, connection, false)
+        name = string_or_nothing(name, false)
+        name_owner = string_or_nothing(name_owner, false)
         f = user_data
         ret = f(connection, name, name_owner)
         nothing
     end
     function GBusNameLostCallback(connection, name, user_data)
+        connection = convert(GDBusConnection, connection, false)
+        name = string_or_nothing(name, false)
         f = user_data
         ret = f(connection, name)
         nothing
     end
     function GBusNameVanishedCallback(connection, name, user_data)
+        connection = convert(GDBusConnection, connection, false)
+        name = string_or_nothing(name, false)
         f = user_data
         ret = f(connection, name)
         nothing
     end
     function GCancellableSourceFunc(cancellable, data)
+        cancellable = convert_if_not_null(GCancellable, cancellable, false)
         f = data
         ret = f(cancellable)
         convert(Cint, ret)
     end
     function GDBusInterfaceGetPropertyFunc(connection, sender, object_path, interface_name, property_name, error, user_data)
+        connection = convert(GDBusConnection, connection, false)
+        sender = string_or_nothing(sender, false)
+        object_path = string_or_nothing(object_path, false)
+        interface_name = string_or_nothing(interface_name, false)
+        property_name = string_or_nothing(property_name, false)
         f = user_data
         ret = f(connection, sender, object_path, interface_name, property_name, error)
         convert(Ptr{GVariant}, ret)
     end
     function GDBusInterfaceMethodCallFunc(connection, sender, object_path, interface_name, method_name, parameters, invocation, user_data)
+        connection = convert(GDBusConnection, connection, false)
+        sender = string_or_nothing(sender, false)
+        object_path = string_or_nothing(object_path, false)
+        interface_name = string_or_nothing(interface_name, false)
+        method_name = string_or_nothing(method_name, false)
+        parameters = convert(GVariant, parameters)
+        invocation = convert(GDBusMethodInvocation, invocation, true)
         f = user_data
         ret = f(connection, sender, object_path, interface_name, method_name, parameters, invocation)
         nothing
     end
     function GDBusInterfaceSetPropertyFunc(connection, sender, object_path, interface_name, property_name, value, error, user_data)
+        connection = convert(GDBusConnection, connection, false)
+        sender = string_or_nothing(sender, false)
+        object_path = string_or_nothing(object_path, false)
+        interface_name = string_or_nothing(interface_name, false)
+        property_name = string_or_nothing(property_name, false)
+        value = convert(GVariant, value)
         f = user_data
         ret = f(connection, sender, object_path, interface_name, property_name, value, error)
         convert(Cint, ret)
     end
     function GDBusMessageFilterFunction(connection, message, incoming, user_data)
+        connection = convert(GDBusConnection, connection, false)
+        message = convert(GDBusMessage, message, true)
+        incoming = convert(Bool, incoming)
         f = user_data
         ret = f(connection, message, incoming)
         convert(Ptr{GObject}, ret)
     end
     function GDBusProxyTypeFunc(manager, object_path, interface_name, data)
+        manager = convert(GDBusObjectManagerClient, manager, false)
+        object_path = string_or_nothing(object_path, false)
+        interface_name = string_or_nothing(interface_name, false)
         f = data
         ret = f(manager, object_path, interface_name)
         convert(UInt64, ret)
     end
     function GDBusSignalCallback(connection, sender_name, object_path, interface_name, signal_name, parameters, user_data)
+        connection = convert(GDBusConnection, connection, false)
+        sender_name = string_or_nothing(sender_name, false)
+        object_path = string_or_nothing(object_path, false)
+        interface_name = string_or_nothing(interface_name, false)
+        signal_name = string_or_nothing(signal_name, false)
+        parameters = convert(GVariant, parameters)
         f = user_data
         ret = f(connection, sender_name, object_path, interface_name, signal_name, parameters)
         nothing
     end
     function GDBusSubtreeDispatchFunc(connection, sender, object_path, interface_name, node, out_user_data, user_data)
+        connection = convert(GDBusConnection, connection, false)
+        sender = string_or_nothing(sender, false)
+        object_path = string_or_nothing(object_path, false)
+        interface_name = string_or_nothing(interface_name, false)
+        node = string_or_nothing(node, false)
+        out_user_data = convert(Nothing, out_user_data)
         f = user_data
         ret = f(connection, sender, object_path, interface_name, node, out_user_data)
         convert(Ptr{_GDBusInterfaceVTable}, ret)
     end
     function GDBusSubtreeEnumerateFunc(connection, sender, object_path, user_data)
+        connection = convert(GDBusConnection, connection, false)
+        sender = string_or_nothing(sender, false)
+        object_path = string_or_nothing(object_path, false)
         f = user_data
         ret = f(connection, sender, object_path)
         convert(Ptr{Cstring}, ret)
     end
     function GDBusSubtreeIntrospectFunc(connection, sender, object_path, node, user_data)
+        connection = convert(GDBusConnection, connection, false)
+        sender = string_or_nothing(sender, false)
+        object_path = string_or_nothing(object_path, false)
+        node = string_or_nothing(node, false)
         f = user_data
         ret = f(connection, sender, object_path, node)
         convert(Ptr{Ptr{_GDBusInterfaceInfo}}, ret)
     end
     function GDatagramBasedSourceFunc(datagram_based, condition, data)
+        datagram_based = begin
+                leaftype = GLib.find_leaf_type(datagram_based)
+                convert(leaftype, datagram_based, false)
+            end
+        condition = IOCondition(condition)
         f = data
         ret = f(datagram_based, condition)
         convert(Cint, ret)
     end
     function GDesktopAppLaunchCallback(appinfo, pid, user_data)
+        appinfo = convert(GDesktopAppInfo, appinfo, false)
         f = user_data
         ret = f(appinfo, pid)
         nothing
     end
     function GFileMeasureProgressCallback(reporting, current_size, num_dirs, num_files, data)
+        reporting = convert(Bool, reporting)
         f = data
         ret = f(reporting, current_size, num_dirs, num_files)
         nothing
@@ -3704,41 +3771,55 @@ $(Expr(:toplevel, quote
         nothing
     end
     function GFileReadMoreCallback(file_contents, file_size, callback_data)
+        file_contents = string_or_nothing(file_contents, false)
         f = callback_data
         ret = f(file_contents, file_size)
         convert(Cint, ret)
     end
     function GIOSchedulerJobFunc(job, cancellable, data)
+        job = convert(GIOSchedulerJob, job)
+        cancellable = convert_if_not_null(GCancellable, cancellable, false)
         f = data
         ret = f(job, cancellable)
         convert(Cint, ret)
     end
     function GPollableSourceFunc(pollable_stream, data)
+        pollable_stream = convert(GObject, pollable_stream, false)
         f = data
         ret = f(pollable_stream)
         convert(Cint, ret)
     end
     function GSettingsBindGetMapping(value, variant, user_data)
+        value = convert(Union{GValue, Ref{_GValue}}, value, false)
+        variant = convert(GVariant, variant)
         f = user_data
         ret = f(value, variant)
         convert(Cint, ret)
     end
     function GSettingsBindSetMapping(value, expected_type, user_data)
+        value = convert(Union{GValue, Ref{_GValue}}, value, false)
+        expected_type = convert(GVariantType, expected_type, false)
         f = user_data
         ret = f(value, expected_type)
         convert(Ptr{GVariant}, ret)
     end
     function GSettingsGetMapping(value, result, user_data)
+        value = convert(GVariant, value)
+        result = convert(Maybe(Nothing), result)
         f = user_data
         ret = f(value, result)
         convert(Cint, ret)
     end
     function GSocketSourceFunc(socket, condition, data)
+        socket = convert(GSocket, socket, false)
+        condition = IOCondition(condition)
         f = data
         ret = f(socket, condition)
         convert(Cint, ret)
     end
     function GVfsFileLookupFunc(vfs, identifier, user_data)
+        vfs = convert(GVfs, vfs, false)
+        identifier = string_or_nothing(identifier, false)
         f = user_data
         ret = f(vfs, identifier)
         convert(Ptr{GObject}, ret)

--- a/src/gen/gio_structs
+++ b/src/gen/gio_structs
@@ -3663,7 +3663,7 @@ $(Expr(:toplevel, quote
         property_name = string_or_nothing(property_name, false)
         f = user_data
         ret = f(connection, sender, object_path, interface_name, property_name, error)
-        convert(Ptr{GVariant}, ret)
+        ret.handle
     end
     function GDBusInterfaceMethodCallFunc(connection, sender, object_path, interface_name, method_name, parameters, invocation, user_data)
         connection = convert(GDBusConnection, connection, false)
@@ -3694,7 +3694,7 @@ $(Expr(:toplevel, quote
         incoming = convert(Bool, incoming)
         f = user_data
         ret = f(connection, message, incoming)
-        convert(Ptr{GObject}, ret)
+        ret.handle
     end
     function GDBusProxyTypeFunc(manager, object_path, interface_name, data)
         manager = convert(GDBusObjectManagerClient, manager, false)
@@ -3801,7 +3801,7 @@ $(Expr(:toplevel, quote
         expected_type = convert(GVariantType, expected_type, false)
         f = user_data
         ret = f(value, expected_type)
-        convert(Ptr{GVariant}, ret)
+        ret.handle
     end
     function GSettingsGetMapping(value, result, user_data)
         value = convert(GVariant, value)
@@ -3822,7 +3822,7 @@ $(Expr(:toplevel, quote
         identifier = string_or_nothing(identifier, false)
         f = user_data
         ret = f(vfs, identifier)
-        convert(Ptr{GObject}, ret)
+        ret.handle
     end
     function on_launch_failed(f, object::GAppLaunchContext, user_data = object, after = false)
         GLib.signal_connect_generic(f, object, "launch-failed", Nothing, (Cstring,), after, user_data)

--- a/src/gen/glib_structs
+++ b/src/gen/glib_structs
@@ -575,16 +575,20 @@ $(Expr(:toplevel, quote
         nothing
     end
     function GCompareDataFunc(a, b, user_data)
+        a = convert(Maybe(Nothing), a)
+        b = convert(Maybe(Nothing), b)
         f = user_data
         ret = f(a, b)
         convert(Int32, ret)
     end
     function GCopyFunc(src, data)
+        src = convert(Nothing, src)
         f = data
         ret = f(src)
         convert(Ptr{Nothing}, ret)
     end
     function GDataForeachFunc(key_id, data, user_data)
+        data = convert(Maybe(Nothing), data)
         f = user_data
         ret = f(key_id, data)
         nothing
@@ -595,11 +599,14 @@ $(Expr(:toplevel, quote
         nothing
     end
     function GDuplicateFunc(data, user_data)
+        data = convert(Maybe(Nothing), data)
         f = user_data
         ret = f(data)
         convert(Ptr{Nothing}, ret)
     end
     function GEqualFuncFull(a, b, user_data)
+        a = convert(Maybe(Nothing), a)
+        b = convert(Maybe(Nothing), b)
         f = user_data
         ret = f(a, b)
         convert(Cint, ret)
@@ -610,16 +617,21 @@ $(Expr(:toplevel, quote
         nothing
     end
     function GFunc(data, user_data)
+        data = convert(Maybe(Nothing), data)
         f = user_data
         ret = f(data)
         nothing
     end
     function GHFunc(key, value, user_data)
+        key = convert(Maybe(Nothing), key)
+        value = convert(Maybe(Nothing), value)
         f = user_data
         ret = f(key, value)
         nothing
     end
     function GHRFunc(key, value, user_data)
+        key = convert(Maybe(Nothing), key)
+        value = convert(Maybe(Nothing), value)
         f = user_data
         ret = f(key, value)
         convert(Cint, ret)
@@ -630,11 +642,13 @@ $(Expr(:toplevel, quote
         convert(Cint, ret)
     end
     function GHookCheckMarshaller(hook, marshal_data)
+        hook = convert(Union{GHook, Ref{_GHook}}, hook)
         f = marshal_data
         ret = f(hook)
         convert(Cint, ret)
     end
     function GHookFindFunc(hook, data)
+        hook = convert(Union{GHook, Ref{_GHook}}, hook)
         f = data
         ret = f(hook)
         convert(Cint, ret)
@@ -645,56 +659,76 @@ $(Expr(:toplevel, quote
         nothing
     end
     function GHookMarshaller(hook, marshal_data)
+        hook = convert(Union{GHook, Ref{_GHook}}, hook)
         f = marshal_data
         ret = f(hook)
         nothing
     end
     function GIOFunc(source, condition, data)
+        source = convert(Union{GIOChannel, Ref{_GIOChannel}}, source, false)
+        condition = IOCondition(condition)
         f = data
         ret = f(source, condition)
         convert(Cint, ret)
     end
     function GLogFunc(log_domain, log_level, message, user_data)
+        log_domain = string_or_nothing(log_domain, false)
+        log_level = LogLevelFlags(log_level)
+        message = string_or_nothing(message, false)
         f = user_data
         ret = f(log_domain, log_level, message)
         nothing
     end
     function GLogWriterFunc(log_level, fields, n_fields, user_data)
+        log_level = LogLevelFlags(log_level)
+        fields = collect(unsafe_wrap(Vector{_GLogField}, fields, m_n_fields[]))
         f = user_data
         ret = f(log_level, fields, n_fields)
         convert(UInt32, ret)
     end
     function GNodeForeachFunc(node, data)
+        node = convert(Union{GNode, Ref{_GNode}}, node)
         f = data
         ret = f(node)
         nothing
     end
     function GNodeTraverseFunc(node, data)
+        node = convert(Union{GNode, Ref{_GNode}}, node)
         f = data
         ret = f(node)
         convert(Cint, ret)
     end
     function GOptionArgFunc(option_name, value, data)
+        option_name = string_or_nothing(option_name, false)
+        value = string_or_nothing(value, false)
         f = data
         ret = f(option_name, value)
         convert(Cint, ret)
     end
     function GOptionErrorFunc(context, group, data)
+        context = convert(GOptionContext, context)
+        group = convert(GOptionGroup, group, false)
         f = data
         ret = f(context, group)
         nothing
     end
     function GOptionParseFunc(context, group, data)
+        context = convert(GOptionContext, context)
+        group = convert(GOptionGroup, group, false)
         f = data
         ret = f(context, group)
         convert(Cint, ret)
     end
     function GRegexEvalCallback(match_info, result, user_data)
+        match_info = convert(GMatchInfo, match_info, false)
+        result = convert(Union{GString, Ref{_GString}}, result, false)
         f = user_data
         ret = f(match_info, result)
         convert(Cint, ret)
     end
     function GSequenceIterCompareFunc(a, b, data)
+        a = convert(GSequenceIter, a)
+        b = convert(GSequenceIter, b)
         f = data
         ret = f(a, b)
         convert(Int32, ret)
@@ -720,11 +754,15 @@ $(Expr(:toplevel, quote
         nothing
     end
     function GTestFixtureFunc(fixture, user_data)
+        fixture = convert(Nothing, fixture)
         f = user_data
         ret = f(fixture)
         nothing
     end
     function GTestLogFatalFunc(log_domain, log_level, message, user_data)
+        log_domain = string_or_nothing(log_domain, false)
+        log_level = LogLevelFlags(log_level)
+        message = string_or_nothing(message, false)
         f = user_data
         ret = f(log_domain, log_level, message)
         convert(Cint, ret)
@@ -735,21 +773,26 @@ $(Expr(:toplevel, quote
         convert(Ptr{Nothing}, ret)
     end
     function GTranslateFunc(str, data)
+        str = string_or_nothing(str, false)
         f = data
         ret = f(str)
         convert(Cstring, ret)
     end
     function GTraverseFunc(key, value, data)
+        key = convert(Maybe(Nothing), key)
+        value = convert(Maybe(Nothing), value)
         f = data
         ret = f(key, value)
         convert(Cint, ret)
     end
     function GTraverseNodeFunc(node, data)
+        node = convert(GTreeNode, node)
         f = data
         ret = f(node)
         convert(Cint, ret)
     end
     function GUnixFDSourceFunc(fd, condition, user_data)
+        condition = IOCondition(condition)
         f = user_data
         ret = f(fd, condition)
         convert(Cint, ret)

--- a/src/gen/gobject_structs
+++ b/src/gen/gobject_structs
@@ -323,41 +323,57 @@ $(Expr(:toplevel, quote
             end
     end
     function GBindingTransformFunc(binding, from_value, to_value, user_data)
+        binding = convert(GBinding, binding, false)
+        from_value = convert(Union{GValue, Ref{_GValue}}, from_value, false)
+        to_value = convert(Union{GValue, Ref{_GValue}}, to_value, false)
         f = user_data
         ret = f(binding, from_value, to_value)
         convert(Cint, ret)
     end
     function GClassFinalizeFunc(g_class, class_data)
+        g_class = convert(Union{GTypeClass, Ref{_GTypeClass}}, g_class)
         f = class_data
         ret = f(g_class)
         nothing
     end
     function GClassInitFunc(g_class, class_data)
+        g_class = convert(Union{GTypeClass, Ref{_GTypeClass}}, g_class)
         f = class_data
         ret = f(g_class)
         nothing
     end
     function GClosureMarshal(closure, return_value, n_param_values, param_values, invocation_hint, marshal_data)
+        closure = convert(Union{GClosure, Ref{_GClosure}}, closure, false)
+        return_value = convert_if_not_null(Union{GValue, Ref{_GValue}}, return_value, false)
+        param_values = collect(unsafe_wrap(Vector{_GValue}, param_values, m_n_param_values[]))
+        invocation_hint = convert(Maybe(Nothing), invocation_hint)
         f = marshal_data
         ret = f(closure, return_value, n_param_values, param_values, invocation_hint)
         nothing
     end
     function GInterfaceFinalizeFunc(g_iface, iface_data)
+        g_iface = convert(Union{GTypeInterface, Ref{_GTypeInterface}}, g_iface)
         f = iface_data
         ret = f(g_iface)
         nothing
     end
     function GInterfaceInitFunc(g_iface, iface_data)
+        g_iface = convert(Union{GTypeInterface, Ref{_GTypeInterface}}, g_iface)
         f = iface_data
         ret = f(g_iface)
         nothing
     end
     function GSignalAccumulator(ihint, return_accu, handler_return, data)
+        ihint = convert(Union{GSignalInvocationHint, Ref{_GSignalInvocationHint}}, ihint)
+        return_accu = convert(Union{GValue, Ref{_GValue}}, return_accu, false)
+        handler_return = convert(Union{GValue, Ref{_GValue}}, handler_return, false)
         f = data
         ret = f(ihint, return_accu, handler_return)
         convert(Cint, ret)
     end
     function GSignalEmissionHook(ihint, n_param_values, param_values, data)
+        ihint = convert(Union{GSignalInvocationHint, Ref{_GSignalInvocationHint}}, ihint)
+        param_values = collect(unsafe_wrap(Vector{_GValue}, param_values, m_n_param_values[]))
         f = data
         ret = f(ihint, n_param_values, param_values)
         convert(Cint, ret)

--- a/src/gen/graphene_methods
+++ b/src/gen/graphene_methods
@@ -80,6 +80,12 @@ $(Expr(:toplevel, quote
         _size = m_size[]
         _size
     end
+    function get_vertices(instance::Union{GrapheneBox, Ref{_GrapheneBox}})
+        m_vertices = Ref{Ptr{_GrapheneVec3}}()
+        ret = ccall(("graphene_box_get_vertices", libgraphene), Nothing, (Ptr{_GrapheneBox}, Ptr{Ptr{_GrapheneVec3}}), instance, m_vertices)
+        _vertices = m_vertices[]
+        _vertices
+    end
     function get_width(instance::Union{GrapheneBox, Ref{_GrapheneBox}})
         ret = ccall(("graphene_box_get_width", libgraphene), Float32, (Ptr{_GrapheneBox},), instance)
         ret
@@ -254,6 +260,12 @@ $(Expr(:toplevel, quote
     function free(instance::Union{GrapheneFrustum, Ref{_GrapheneFrustum}})
         ret = ccall(("graphene_frustum_free", libgraphene), Nothing, (Ptr{_GrapheneFrustum},), instance)
         nothing
+    end
+    function get_planes(instance::Union{GrapheneFrustum, Ref{_GrapheneFrustum}})
+        m_planes = Ref{Ptr{_GraphenePlane}}()
+        ret = ccall(("graphene_frustum_get_planes", libgraphene), Nothing, (Ptr{_GrapheneFrustum}, Ptr{Ptr{_GraphenePlane}}), instance, m_planes)
+        _planes = m_planes[]
+        _planes
     end
     function init(instance::Union{GrapheneFrustum, Ref{_GrapheneFrustum}}, _p0::Union{GraphenePlane, Ref{_GraphenePlane}}, _p1::Union{GraphenePlane, Ref{_GraphenePlane}}, _p2::Union{GraphenePlane, Ref{_GraphenePlane}}, _p3::Union{GraphenePlane, Ref{_GraphenePlane}}, _p4::Union{GraphenePlane, Ref{_GraphenePlane}}, _p5::Union{GraphenePlane, Ref{_GraphenePlane}})
         ret = ccall(("graphene_frustum_init", libgraphene), Ptr{_GrapheneFrustum}, (Ptr{_GrapheneFrustum}, Ptr{_GraphenePlane}, Ptr{_GraphenePlane}, Ptr{_GraphenePlane}, Ptr{_GraphenePlane}, Ptr{_GraphenePlane}, Ptr{_GraphenePlane}), instance, _p0, _p1, _p2, _p3, _p4, _p5)
@@ -552,6 +564,12 @@ $(Expr(:toplevel, quote
         _x_0 = m_x_0[]
         _y_0 = m_y_0[]
         (ret2, _xx, _yx, _xy, _yy, _x_0, _y_0)
+    end
+    function to_float(instance::Union{GrapheneMatrix, Ref{_GrapheneMatrix}})
+        m_v = Ref{Ptr{Float32}}()
+        ret = ccall(("graphene_matrix_to_float", libgraphene), Nothing, (Ptr{_GrapheneMatrix}, Ptr{Ptr{Float32}}), instance, m_v)
+        _v = m_v[]
+        _v
     end
     function transform_bounds(instance::Union{GrapheneMatrix, Ref{_GrapheneMatrix}}, _r::Union{GrapheneRect, Ref{_GrapheneRect}})
         m_res = Ref{_GrapheneRect}()
@@ -1191,6 +1209,12 @@ $(Expr(:toplevel, quote
         _p = m_p[]
         _p
     end
+    function get_vertices(instance::Union{GrapheneRect, Ref{_GrapheneRect}})
+        m_vertices = Ref{Ptr{_GrapheneVec2}}()
+        ret = ccall(("graphene_rect_get_vertices", libgraphene), Nothing, (Ptr{_GrapheneRect}, Ptr{Ptr{_GrapheneVec2}}), instance, m_vertices)
+        _vertices = m_vertices[]
+        _vertices
+    end
     function get_width(instance::Union{GrapheneRect, Ref{_GrapheneRect}})
         ret = ccall(("graphene_rect_get_width", libgraphene), Float32, (Ptr{_GrapheneRect},), instance)
         ret
@@ -1567,6 +1591,12 @@ $(Expr(:toplevel, quote
         _res = m_res[]
         _res
     end
+    function to_float(instance::Union{GrapheneVec2, Ref{_GrapheneVec2}})
+        m_dest = Ref{Ptr{Float32}}()
+        ret = ccall(("graphene_vec2_to_float", libgraphene), Nothing, (Ptr{_GrapheneVec2}, Ptr{Ptr{Float32}}), instance, m_dest)
+        _dest = m_dest[]
+        _dest
+    end
     function Vec4_alloc()
         ret = ccall(("graphene_vec4_alloc", libgraphene), Ptr{_GrapheneVec4}, ())
         ret2 = convert(Union{GrapheneVec4, Ref{_GrapheneVec4}}, ret, true)
@@ -1707,6 +1737,12 @@ $(Expr(:toplevel, quote
         ret = ccall(("graphene_vec4_subtract", libgraphene), Nothing, (Ptr{_GrapheneVec4}, Ptr{_GrapheneVec4}, Ptr{_GrapheneVec4}), instance, _b, m_res)
         _res = m_res[]
         _res
+    end
+    function to_float(instance::Union{GrapheneVec4, Ref{_GrapheneVec4}})
+        m_dest = Ref{Ptr{Float32}}()
+        ret = ccall(("graphene_vec4_to_float", libgraphene), Nothing, (Ptr{_GrapheneVec4}, Ptr{Ptr{Float32}}), instance, m_dest)
+        _dest = m_dest[]
+        _dest
     end
 end))
 end

--- a/src/gen/gsk4_methods
+++ b/src/gen/gsk4_methods
@@ -263,6 +263,10 @@ $(Expr(:toplevel, quote
         ret2 = convert(Union{GskRoundedRect, Ref{_GskRoundedRect}}, ret)
         ret2
     end
+    function get_widths(instance::GskBorderNode)
+        ret = ccall(("gsk_border_node_get_widths", libgtk4), Ptr{Float32}, (Ptr{GskRenderNode},), instance)
+        ret
+    end
     function BroadwayRenderer_new()
         ret = ccall(("gsk_broadway_renderer_new", libgtk4), Ptr{GObject}, ())
         ret2 = GskBroadwayRendererLeaf(ret, true)

--- a/src/gen/gtk4_functions
+++ b/src/gen/gtk4_functions
@@ -372,7 +372,7 @@ $(Expr(:toplevel, quote
         _tree_model = m_tree_model[]
         _tree_model = GLib.find_leaf_type_if_not_null(_tree_model, false)
         _path = m_path[]
-        _path = convert_if_not_null(Maybe(GtkTreePath), _path, true)
+        _path = convert_if_not_null(GtkTreePath, _path, true)
         (ret2, _tree_model, _path)
     end
     function tree_row_reference_deleted(_proxy::GObject, _path::GtkTreePath)

--- a/src/gen/gtk4_methods
+++ b/src/gen/gtk4_methods
@@ -2290,7 +2290,7 @@ $(Expr(:toplevel, quote
         err = err_buf()
         ret = ccall(("gtk_color_dialog_choose_rgba_finish", libgtk4), Ptr{_GdkRGBA}, (Ptr{GObject}, Ptr{GObject}, Ptr{Ptr{GError}}), instance, _result, err)
         check_err(err)
-        ret2 = convert_if_not_null(Union{GdkRGBA, Ref{_GdkRGBA}}, ret, true)
+        ret2 = convert_if_not_null(GdkRGBA, ret, true)
         ret2
     end
     function get_modal(instance::GtkColorDialog)
@@ -3286,7 +3286,7 @@ $(Expr(:toplevel, quote
     end
     function get_value(instance::GtkDropTarget)
         ret = ccall(("gtk_drop_target_get_value", libgtk4), Ptr{_GValue}, (Ptr{GObject},), instance)
-        ret2 = convert_if_not_null(Union{GValue, Ref{_GValue}}, ret, false)
+        ret2 = convert_if_not_null(GValue, ret, false)
         ret2
     end
     function reject(instance::GtkDropTarget)
@@ -5897,7 +5897,7 @@ $(Expr(:toplevel, quote
         m_pos = Ref{UInt32}()
         ret = ccall(("gtk_icon_view_get_drag_dest_item", libgtk4), Nothing, (Ptr{GObject}, Ptr{Ptr{GtkTreePath}}, Ptr{UInt32}), instance, m_path, m_pos)
         _path = m_path[]
-        _path = convert_if_not_null(Maybe(GtkTreePath), _path, true)
+        _path = convert_if_not_null(GtkTreePath, _path, true)
         _pos = m_pos[]
         _pos = IconViewDropPosition(_pos)
         (_path, _pos)
@@ -12279,9 +12279,9 @@ $(Expr(:toplevel, quote
         m_focus_column = Ref{Ptr{GObject}}()
         ret = ccall(("gtk_tree_view_get_cursor", libgtk4), Nothing, (Ptr{GObject}, Ptr{Ptr{GtkTreePath}}, Ptr{Ptr{GObject}}), instance, m_path, m_focus_column)
         _path = m_path[]
-        _path = convert_if_not_null(Maybe(GtkTreePath), _path, true)
+        _path = convert_if_not_null(GtkTreePath, _path, true)
         _focus_column = m_focus_column[]
-        _focus_column = convert_if_not_null(Maybe(GtkTreeViewColumn), _focus_column, false)
+        _focus_column = convert_if_not_null(GtkTreeViewColumn, _focus_column, false)
         (_path, _focus_column)
     end
     function get_dest_row_at_pos(instance::GtkTreeView, _drag_x::Integer, _drag_y::Integer)
@@ -12290,7 +12290,7 @@ $(Expr(:toplevel, quote
         ret = ccall(("gtk_tree_view_get_dest_row_at_pos", libgtk4), Cint, (Ptr{GObject}, Int32, Int32, Ptr{Ptr{GtkTreePath}}, Ptr{UInt32}), instance, _drag_x, _drag_y, m_path, m_pos)
         ret2 = convert(Bool, ret)
         _path = m_path[]
-        _path = convert_if_not_null(Maybe(GtkTreePath), _path, true)
+        _path = convert_if_not_null(GtkTreePath, _path, true)
         _pos = m_pos[]
         _pos = TreeViewDropPosition(_pos)
         (ret2, _path, _pos)
@@ -12300,7 +12300,7 @@ $(Expr(:toplevel, quote
         m_pos = Ref{UInt32}()
         ret = ccall(("gtk_tree_view_get_drag_dest_row", libgtk4), Nothing, (Ptr{GObject}, Ptr{Ptr{GtkTreePath}}, Ptr{UInt32}), instance, m_path, m_pos)
         _path = m_path[]
-        _path = convert_if_not_null(Maybe(GtkTreePath), _path, true)
+        _path = convert_if_not_null(GtkTreePath, _path, true)
         _pos = m_pos[]
         _pos = TreeViewDropPosition(_pos)
         (_path, _pos)
@@ -12371,9 +12371,9 @@ $(Expr(:toplevel, quote
         ret = ccall(("gtk_tree_view_get_path_at_pos", libgtk4), Cint, (Ptr{GObject}, Int32, Int32, Ptr{Ptr{GtkTreePath}}, Ptr{Ptr{GObject}}, Ptr{Int32}, Ptr{Int32}), instance, _x, _y, m_path, m_column, m_cell_x, m_cell_y)
         ret2 = convert(Bool, ret)
         _path = m_path[]
-        _path = convert_if_not_null(Maybe(GtkTreePath), _path, true)
+        _path = convert_if_not_null(GtkTreePath, _path, true)
         _column = m_column[]
-        _column = convert_if_not_null(Maybe(GtkTreeViewColumn), _column, false)
+        _column = convert_if_not_null(GtkTreeViewColumn, _column, false)
         _cell_x = m_cell_x[]
         _cell_y = m_cell_y[]
         (ret2, _path, _column, _cell_x, _cell_y)
@@ -12453,9 +12453,9 @@ $(Expr(:toplevel, quote
         ret = ccall(("gtk_tree_view_is_blank_at_pos", libgtk4), Cint, (Ptr{GObject}, Int32, Int32, Ptr{Ptr{GtkTreePath}}, Ptr{Ptr{GObject}}, Ptr{Int32}, Ptr{Int32}), instance, _x, _y, m_path, m_column, m_cell_x, m_cell_y)
         ret2 = convert(Bool, ret)
         _path = m_path[]
-        _path = convert_if_not_null(Maybe(GtkTreePath), _path, true)
+        _path = convert_if_not_null(GtkTreePath, _path, true)
         _column = m_column[]
-        _column = convert_if_not_null(Maybe(GtkTreeViewColumn), _column, false)
+        _column = convert_if_not_null(GtkTreeViewColumn, _column, false)
         _cell_x = m_cell_x[]
         _cell_y = m_cell_y[]
         (ret2, _path, _column, _cell_x, _cell_y)

--- a/src/gen/gtk4_structs
+++ b/src/gen/gtk4_structs
@@ -8614,31 +8614,51 @@ $(Expr(:toplevel, quote
         convert(Int32, ret)
     end
     function GtkCellAllocCallback(renderer, cell_area, cell_background, data)
+        renderer = convert(GtkCellRenderer, renderer, false)
+        cell_area = convert(Union{GdkRectangle, Ref{_GdkRectangle}}, cell_area, false)
+        cell_background = convert(Union{GdkRectangle, Ref{_GdkRectangle}}, cell_background, false)
         f = data
         ret = f(renderer, cell_area, cell_background)
         convert(Cint, ret)
     end
     function GtkCellCallback(renderer, data)
+        renderer = convert(GtkCellRenderer, renderer, false)
         f = data
         ret = f(renderer)
         convert(Cint, ret)
     end
     function GtkCellLayoutDataFunc(cell_layout, cell, tree_model, iter, data)
+        cell_layout = begin
+                leaftype = GLib.find_leaf_type(cell_layout)
+                convert(leaftype, cell_layout, false)
+            end
+        cell = convert(GtkCellRenderer, cell, false)
+        tree_model = begin
+                leaftype = GLib.find_leaf_type(tree_model)
+                convert(leaftype, tree_model, false)
+            end
+        iter = convert(Union{GtkTreeIter, Ref{_GtkTreeIter}}, iter, false)
         f = data
         ret = f(cell_layout, cell, tree_model, iter)
         nothing
     end
     function GtkCustomFilterFunc(item, user_data)
+        item = convert(GObject, item, false)
         f = user_data
         ret = f(item)
         convert(Cint, ret)
     end
     function GtkDrawingAreaDrawFunc(drawing_area, cr, width, height, user_data)
+        drawing_area = convert(GtkDrawingArea, drawing_area, false)
+        cr = convert(cairoContext, cr, false)
         f = user_data
         ret = f(drawing_area, cr, width, height)
         nothing
     end
     function GtkEntryCompletionMatchFunc(completion, key, iter, user_data)
+        completion = convert(GtkEntryCompletion, completion, false)
+        key = string_or_nothing(key, false)
+        iter = convert(Union{GtkTreeIter, Ref{_GtkTreeIter}}, iter, false)
         f = user_data
         ret = f(completion, key, iter)
         convert(Cint, ret)
@@ -8649,91 +8669,118 @@ $(Expr(:toplevel, quote
         nothing
     end
     function GtkFlowBoxCreateWidgetFunc(item, user_data)
+        item = convert(GObject, item, false)
         f = user_data
         ret = f(item)
         convert(Ptr{GObject}, ret)
     end
     function GtkFlowBoxFilterFunc(child, user_data)
+        child = convert(GtkFlowBoxChild, child, false)
         f = user_data
         ret = f(child)
         convert(Cint, ret)
     end
     function GtkFlowBoxForeachFunc(box, child, user_data)
+        box = convert(GtkFlowBox, box, false)
+        child = convert(GtkFlowBoxChild, child, false)
         f = user_data
         ret = f(box, child)
         nothing
     end
     function GtkFlowBoxSortFunc(child1, child2, user_data)
+        child1 = convert(GtkFlowBoxChild, child1, false)
+        child2 = convert(GtkFlowBoxChild, child2, false)
         f = user_data
         ret = f(child1, child2)
         convert(Int32, ret)
     end
     function GtkFontFilterFunc(family, face, data)
+        family = convert(PangoFontFamily, family, false)
+        face = convert(PangoFontFace, face, false)
         f = data
         ret = f(family, face)
         convert(Cint, ret)
     end
     function GtkIconViewForeachFunc(icon_view, path, data)
+        icon_view = convert(GtkIconView, icon_view, false)
+        path = convert(GtkTreePath, path, false)
         f = data
         ret = f(icon_view, path)
         nothing
     end
     function GtkListBoxCreateWidgetFunc(item, user_data)
+        item = convert(GObject, item, false)
         f = user_data
         ret = f(item)
         convert(Ptr{GObject}, ret)
     end
     function GtkListBoxFilterFunc(row, user_data)
+        row = convert(GtkListBoxRow, row, false)
         f = user_data
         ret = f(row)
         convert(Cint, ret)
     end
     function GtkListBoxForeachFunc(box, row, user_data)
+        box = convert(GtkListBox, box, false)
+        row = convert(GtkListBoxRow, row, false)
         f = user_data
         ret = f(box, row)
         nothing
     end
     function GtkListBoxSortFunc(row1, row2, user_data)
+        row1 = convert(GtkListBoxRow, row1, false)
+        row2 = convert(GtkListBoxRow, row2, false)
         f = user_data
         ret = f(row1, row2)
         convert(Int32, ret)
     end
     function GtkListBoxUpdateHeaderFunc(row, before, user_data)
+        row = convert(GtkListBoxRow, row, false)
+        before = convert_if_not_null(GtkListBoxRow, before, false)
         f = user_data
         ret = f(row, before)
         nothing
     end
     function GtkMapListModelMapFunc(item, user_data)
+        item = convert(GObject, item, true)
         f = user_data
         ret = f(item)
         convert(Ptr{GObject}, ret)
     end
     function GtkMenuButtonCreatePopupFunc(menu_button, user_data)
+        menu_button = convert(GtkMenuButton, menu_button, false)
         f = user_data
         ret = f(menu_button)
         nothing
     end
     function GtkPageSetupDoneFunc(page_setup, data)
+        page_setup = convert(GtkPageSetup, page_setup, false)
         f = data
         ret = f(page_setup)
         nothing
     end
     function GtkPrintSettingsFunc(key, value, user_data)
+        key = string_or_nothing(key, false)
+        value = string_or_nothing(value, false)
         f = user_data
         ret = f(key, value)
         nothing
     end
     function GtkPrinterFunc(printer, data)
+        printer = convert(GtkPrinter, printer, false)
         f = data
         ret = f(printer)
         convert(Cint, ret)
     end
     function GtkScaleFormatValueFunc(scale, value, user_data)
+        scale = convert(GtkScale, scale, false)
         f = user_data
         ret = f(scale, value)
         convert(Cstring, ret)
     end
     function GtkShortcutFunc(widget, args, user_data)
+        widget = convert(GtkWidget, widget, false)
+        args = convert(Maybe(GVariant), args)
         f = user_data
         ret = f(widget, args)
         convert(Cint, ret)
@@ -8744,71 +8791,134 @@ $(Expr(:toplevel, quote
         convert(Cint, ret)
     end
     function GtkTextTagTableForeach(tag, data)
+        tag = convert(GtkTextTag, tag, false)
         f = data
         ret = f(tag)
         nothing
     end
     function GtkTickCallback(widget, frame_clock, user_data)
+        widget = convert(GtkWidget, widget, false)
+        frame_clock = convert(GdkFrameClock, frame_clock, false)
         f = user_data
         ret = f(widget, frame_clock)
         convert(Cint, ret)
     end
     function GtkTreeCellDataFunc(tree_column, cell, tree_model, iter, data)
+        tree_column = convert(GtkTreeViewColumn, tree_column, false)
+        cell = convert(GtkCellRenderer, cell, false)
+        tree_model = begin
+                leaftype = GLib.find_leaf_type(tree_model)
+                convert(leaftype, tree_model, false)
+            end
+        iter = convert(Union{GtkTreeIter, Ref{_GtkTreeIter}}, iter, false)
         f = data
         ret = f(tree_column, cell, tree_model, iter)
         nothing
     end
     function GtkTreeIterCompareFunc(model, a, b, user_data)
+        model = begin
+                leaftype = GLib.find_leaf_type(model)
+                convert(leaftype, model, false)
+            end
+        a = convert(Union{GtkTreeIter, Ref{_GtkTreeIter}}, a, false)
+        b = convert(Union{GtkTreeIter, Ref{_GtkTreeIter}}, b, false)
         f = user_data
         ret = f(model, a, b)
         convert(Int32, ret)
     end
     function GtkTreeListModelCreateModelFunc(item, user_data)
+        item = convert(GObject, item, false)
         f = user_data
         ret = f(item)
         convert(Ptr{GObject}, ret)
     end
     function GtkTreeModelFilterModifyFunc(model, iter, value, column, data)
+        model = begin
+                leaftype = GLib.find_leaf_type(model)
+                convert(leaftype, model, false)
+            end
+        iter = convert(Union{GtkTreeIter, Ref{_GtkTreeIter}}, iter, false)
         f = data
         ret = f(model, iter, value, column)
         nothing
     end
     function GtkTreeModelFilterVisibleFunc(model, iter, data)
+        model = begin
+                leaftype = GLib.find_leaf_type(model)
+                convert(leaftype, model, false)
+            end
+        iter = convert(Union{GtkTreeIter, Ref{_GtkTreeIter}}, iter, false)
         f = data
         ret = f(model, iter)
         convert(Cint, ret)
     end
     function GtkTreeModelForeachFunc(model, path, iter, data)
+        model = begin
+                leaftype = GLib.find_leaf_type(model)
+                convert(leaftype, model, false)
+            end
+        path = convert(GtkTreePath, path, false)
+        iter = convert(Union{GtkTreeIter, Ref{_GtkTreeIter}}, iter, false)
         f = data
         ret = f(model, path, iter)
         convert(Cint, ret)
     end
     function GtkTreeSelectionForeachFunc(model, path, iter, data)
+        model = begin
+                leaftype = GLib.find_leaf_type(model)
+                convert(leaftype, model, false)
+            end
+        path = convert(GtkTreePath, path, false)
+        iter = convert(Union{GtkTreeIter, Ref{_GtkTreeIter}}, iter, false)
         f = data
         ret = f(model, path, iter)
         nothing
     end
     function GtkTreeSelectionFunc(selection, model, path, path_currently_selected, data)
+        selection = convert(GtkTreeSelection, selection, false)
+        model = begin
+                leaftype = GLib.find_leaf_type(model)
+                convert(leaftype, model, false)
+            end
+        path = convert(GtkTreePath, path, false)
+        path_currently_selected = convert(Bool, path_currently_selected)
         f = data
         ret = f(selection, model, path, path_currently_selected)
         convert(Cint, ret)
     end
     function GtkTreeViewColumnDropFunc(tree_view, column, prev_column, next_column, data)
+        tree_view = convert(GtkTreeView, tree_view, false)
+        column = convert(GtkTreeViewColumn, column, false)
+        prev_column = convert(GtkTreeViewColumn, prev_column, false)
+        next_column = convert(GtkTreeViewColumn, next_column, false)
         f = data
         ret = f(tree_view, column, prev_column, next_column)
         convert(Cint, ret)
     end
     function GtkTreeViewMappingFunc(tree_view, path, user_data)
+        tree_view = convert(GtkTreeView, tree_view, false)
+        path = convert(GtkTreePath, path, false)
         f = user_data
         ret = f(tree_view, path)
         nothing
     end
     function GtkTreeViewRowSeparatorFunc(model, iter, data)
+        model = begin
+                leaftype = GLib.find_leaf_type(model)
+                convert(leaftype, model, false)
+            end
+        iter = convert(Union{GtkTreeIter, Ref{_GtkTreeIter}}, iter, false)
         f = data
         ret = f(model, iter)
         convert(Cint, ret)
     end
     function GtkTreeViewSearchEqualFunc(model, column, key, iter, search_data)
+        model = begin
+                leaftype = GLib.find_leaf_type(model)
+                convert(leaftype, model, false)
+            end
+        key = string_or_nothing(key, false)
+        iter = convert(Union{GtkTreeIter, Ref{_GtkTreeIter}}, iter, false)
         f = search_data
         ret = f(model, column, key, iter)
         convert(Cint, ret)

--- a/src/gen/gtk4_structs
+++ b/src/gen/gtk4_structs
@@ -8672,7 +8672,7 @@ $(Expr(:toplevel, quote
         item = convert(GObject, item, false)
         f = user_data
         ret = f(item)
-        convert(Ptr{GObject}, ret)
+        ret.handle
     end
     function GtkFlowBoxFilterFunc(child, user_data)
         child = convert(GtkFlowBoxChild, child, false)
@@ -8712,7 +8712,7 @@ $(Expr(:toplevel, quote
         item = convert(GObject, item, false)
         f = user_data
         ret = f(item)
-        convert(Ptr{GObject}, ret)
+        ret.handle
     end
     function GtkListBoxFilterFunc(row, user_data)
         row = convert(GtkListBoxRow, row, false)
@@ -8745,7 +8745,7 @@ $(Expr(:toplevel, quote
         item = convert(GObject, item, true)
         f = user_data
         ret = f(item)
-        convert(Ptr{GObject}, ret)
+        ret.handle
     end
     function GtkMenuButtonCreatePopupFunc(menu_button, user_data)
         menu_button = convert(GtkMenuButton, menu_button, false)
@@ -8830,7 +8830,7 @@ $(Expr(:toplevel, quote
         item = convert(GObject, item, false)
         f = user_data
         ret = f(item)
-        convert(Ptr{GObject}, ret)
+        ret.handle
     end
     function GtkTreeModelFilterModifyFunc(model, iter, value, column, data)
         model = begin

--- a/src/gen/gtk4_structs
+++ b/src/gen/gtk4_structs
@@ -8672,7 +8672,10 @@ $(Expr(:toplevel, quote
         item = convert(GObject, item, false)
         f = user_data
         ret = f(item)
-        ret.handle
+        begin
+            ret != C_NULL && GLib.glib_ref(ret)
+            convert(Ptr{GObject}, GLib.get_pointer(ret))
+        end
     end
     function GtkFlowBoxFilterFunc(child, user_data)
         child = convert(GtkFlowBoxChild, child, false)
@@ -8712,7 +8715,10 @@ $(Expr(:toplevel, quote
         item = convert(GObject, item, false)
         f = user_data
         ret = f(item)
-        ret.handle
+        begin
+            ret != C_NULL && GLib.glib_ref(ret)
+            convert(Ptr{GObject}, GLib.get_pointer(ret))
+        end
     end
     function GtkListBoxFilterFunc(row, user_data)
         row = convert(GtkListBoxRow, row, false)
@@ -8745,7 +8751,10 @@ $(Expr(:toplevel, quote
         item = convert(GObject, item, true)
         f = user_data
         ret = f(item)
-        ret.handle
+        begin
+            ret != C_NULL && GLib.glib_ref(ret)
+            convert(Ptr{GObject}, GLib.get_pointer(ret))
+        end
     end
     function GtkMenuButtonCreatePopupFunc(menu_button, user_data)
         menu_button = convert(GtkMenuButton, menu_button, false)
@@ -8830,7 +8839,10 @@ $(Expr(:toplevel, quote
         item = convert(GObject, item, false)
         f = user_data
         ret = f(item)
-        ret.handle
+        begin
+            ret != C_NULL && GLib.glib_ref(ret)
+            convert(Ptr{GObject}, GLib.get_pointer(ret))
+        end
     end
     function GtkTreeModelFilterModifyFunc(model, iter, value, column, data)
         model = begin

--- a/src/gen/pango_methods
+++ b/src/gen/pango_methods
@@ -11,7 +11,7 @@ $(Expr(:toplevel, quote
     end
     function get(instance::PangoAttrIterator, _type)
         ret = ccall(("pango_attr_iterator_get", libpango), Ptr{_PangoAttribute}, (Ptr{PangoAttrIterator}, UInt32), instance, _type)
-        ret2 = convert_if_not_null(Union{PangoAttribute, Ref{_PangoAttribute}}, ret, false)
+        ret2 = convert_if_not_null(PangoAttribute, ret, false)
         ret2
     end
     function get_attrs(instance::PangoAttrIterator)
@@ -139,7 +139,7 @@ $(Expr(:toplevel, quote
     end
     function ref(instance::Union{PangoFontMetrics, Ref{_PangoFontMetrics}})
         ret = ccall(("pango_font_metrics_ref", libpango), Ptr{_PangoFontMetrics}, (Ptr{_PangoFontMetrics},), instance)
-        ret2 = convert_if_not_null(Union{PangoFontMetrics, Ref{_PangoFontMetrics}}, ret, true)
+        ret2 = convert_if_not_null(PangoFontMetrics, ret, true)
         ret2
     end
     function unref(instance::Union{PangoFontMetrics, Ref{_PangoFontMetrics}})
@@ -148,7 +148,7 @@ $(Expr(:toplevel, quote
     end
     function copy(instance::Union{PangoGlyphItemIter, Ref{_PangoGlyphItemIter}})
         ret = ccall(("pango_glyph_item_iter_copy", libpango), Ptr{_PangoGlyphItemIter}, (Ptr{_PangoGlyphItemIter},), instance)
-        ret2 = convert_if_not_null(Union{PangoGlyphItemIter, Ref{_PangoGlyphItemIter}}, ret, true)
+        ret2 = convert_if_not_null(PangoGlyphItemIter, ret, true)
         ret2
     end
     function free(instance::Union{PangoGlyphItemIter, Ref{_PangoGlyphItemIter}})
@@ -231,7 +231,7 @@ $(Expr(:toplevel, quote
     end
     function get_line(instance::PangoLayoutIter)
         ret = ccall(("pango_layout_iter_get_line", libpango), Ptr{_PangoLayoutLine}, (Ptr{PangoLayoutIter},), instance)
-        ret2 = convert_if_not_null(Union{PangoLayoutLine, Ref{_PangoLayoutLine}}, ret, false)
+        ret2 = convert_if_not_null(PangoLayoutLine, ret, false)
         ret2
     end
     function get_line_extents(instance::PangoLayoutIter)
@@ -246,7 +246,7 @@ $(Expr(:toplevel, quote
     end
     function get_line_readonly(instance::PangoLayoutIter)
         ret = ccall(("pango_layout_iter_get_line_readonly", libpango), Ptr{_PangoLayoutLine}, (Ptr{PangoLayoutIter},), instance)
-        ret2 = convert_if_not_null(Union{PangoLayoutLine, Ref{_PangoLayoutLine}}, ret, false)
+        ret2 = convert_if_not_null(PangoLayoutLine, ret, false)
         ret2
     end
     function get_line_yrange(instance::PangoLayoutIter)
@@ -259,7 +259,7 @@ $(Expr(:toplevel, quote
     end
     function get_run(instance::PangoLayoutIter)
         ret = ccall(("pango_layout_iter_get_run", libpango), Ptr{_PangoGlyphItem}, (Ptr{PangoLayoutIter},), instance)
-        ret2 = convert_if_not_null(Union{PangoGlyphItem, Ref{_PangoGlyphItem}}, ret, false)
+        ret2 = convert_if_not_null(PangoGlyphItem, ret, false)
         ret2
     end
     function get_run_baseline(instance::PangoLayoutIter)
@@ -278,7 +278,7 @@ $(Expr(:toplevel, quote
     end
     function get_run_readonly(instance::PangoLayoutIter)
         ret = ccall(("pango_layout_iter_get_run_readonly", libpango), Ptr{_PangoGlyphItem}, (Ptr{PangoLayoutIter},), instance)
-        ret2 = convert_if_not_null(Union{PangoGlyphItem, Ref{_PangoGlyphItem}}, ret, false)
+        ret2 = convert_if_not_null(PangoGlyphItem, ret, false)
         ret2
     end
     function next_char(instance::PangoLayoutIter)
@@ -366,7 +366,7 @@ $(Expr(:toplevel, quote
     end
     function ref(instance::Union{PangoLayoutLine, Ref{_PangoLayoutLine}})
         ret = ccall(("pango_layout_line_ref", libpango), Ptr{_PangoLayoutLine}, (Ptr{_PangoLayoutLine},), instance)
-        ret2 = convert_if_not_null(Union{PangoLayoutLine, Ref{_PangoLayoutLine}}, ret, true)
+        ret2 = convert_if_not_null(PangoLayoutLine, ret, true)
         ret2
     end
     function unref(instance::Union{PangoLayoutLine, Ref{_PangoLayoutLine}})
@@ -388,7 +388,7 @@ $(Expr(:toplevel, quote
     end
     function copy(instance::Union{PangoMatrix, Ref{_PangoMatrix}})
         ret = ccall(("pango_matrix_copy", libpango), Ptr{_PangoMatrix}, (Ptr{_PangoMatrix},), instance)
-        ret2 = convert_if_not_null(Union{PangoMatrix, Ref{_PangoMatrix}}, ret, true)
+        ret2 = convert_if_not_null(PangoMatrix, ret, true)
         ret2
     end
     function free(instance::Union{PangoMatrix, Ref{_PangoMatrix}})
@@ -593,7 +593,7 @@ $(Expr(:toplevel, quote
     end
     function get_matrix(instance::PangoContext)
         ret = ccall(("pango_context_get_matrix", libpango), Ptr{_PangoMatrix}, (Ptr{GObject},), instance)
-        ret2 = convert_if_not_null(Union{PangoMatrix, Ref{_PangoMatrix}}, ret, false)
+        ret2 = convert_if_not_null(PangoMatrix, ret, false)
         ret2
     end
     function get_metrics(instance::PangoContext, _desc::Maybe(PangoFontDescription), _language::Maybe(PangoLanguage))
@@ -1016,7 +1016,7 @@ $(Expr(:toplevel, quote
     end
     function get_line(instance::PangoLayout, _line::Integer)
         ret = ccall(("pango_layout_get_line", libpango), Ptr{_PangoLayoutLine}, (Ptr{GObject}, Int32), instance, _line)
-        ret2 = convert_if_not_null(Union{PangoLayoutLine, Ref{_PangoLayoutLine}}, ret, false)
+        ret2 = convert_if_not_null(PangoLayoutLine, ret, false)
         ret2
     end
     function get_line_count(instance::PangoLayout)
@@ -1025,7 +1025,7 @@ $(Expr(:toplevel, quote
     end
     function get_line_readonly(instance::PangoLayout, _line::Integer)
         ret = ccall(("pango_layout_get_line_readonly", libpango), Ptr{_PangoLayoutLine}, (Ptr{GObject}, Int32), instance, _line)
-        ret2 = convert_if_not_null(Union{PangoLayoutLine, Ref{_PangoLayoutLine}}, ret, false)
+        ret2 = convert_if_not_null(PangoLayoutLine, ret, false)
         ret2
     end
     function get_line_spacing(instance::PangoLayout)
@@ -1300,7 +1300,7 @@ $(Expr(:toplevel, quote
     end
     function get_color(instance::PangoRenderer, _part)
         ret = ccall(("pango_renderer_get_color", libpango), Ptr{_PangoColor}, (Ptr{GObject}, UInt32), instance, _part)
-        ret2 = convert_if_not_null(Union{PangoColor, Ref{_PangoColor}}, ret, false)
+        ret2 = convert_if_not_null(PangoColor, ret, false)
         ret2
     end
     function get_layout(instance::PangoRenderer)
@@ -1310,12 +1310,12 @@ $(Expr(:toplevel, quote
     end
     function get_layout_line(instance::PangoRenderer)
         ret = ccall(("pango_renderer_get_layout_line", libpango), Ptr{_PangoLayoutLine}, (Ptr{GObject},), instance)
-        ret2 = convert_if_not_null(Union{PangoLayoutLine, Ref{_PangoLayoutLine}}, ret, false)
+        ret2 = convert_if_not_null(PangoLayoutLine, ret, false)
         ret2
     end
     function get_matrix(instance::PangoRenderer)
         ret = ccall(("pango_renderer_get_matrix", libpango), Ptr{_PangoMatrix}, (Ptr{GObject},), instance)
-        ret2 = convert_if_not_null(Union{PangoMatrix, Ref{_PangoMatrix}}, ret, false)
+        ret2 = convert_if_not_null(PangoMatrix, ret, false)
         ret2
     end
     function part_changed(instance::PangoRenderer, _part)

--- a/src/gen/pango_structs
+++ b/src/gen/pango_structs
@@ -906,11 +906,14 @@ $(Expr(:toplevel, quote
         convert(Ptr{Nothing}, ret)
     end
     function PangoAttrFilterFunc(attribute, user_data)
+        attribute = convert(Union{PangoAttribute, Ref{_PangoAttribute}}, attribute, false)
         f = user_data
         ret = f(attribute)
         convert(Cint, ret)
     end
     function PangoFontsetForeachFunc(fontset, font, user_data)
+        fontset = convert(PangoFontset, fontset, false)
+        font = convert(PangoFont, font, false)
         f = user_data
         ret = f(fontset, font)
         convert(Cint, ret)

--- a/src/input.jl
+++ b/src/input.jl
@@ -25,7 +25,7 @@ function push!(scale::GtkScale, value, position, markup::AbstractString)
     G_.add_mark(scale, value, convert(Gtk4.PositionType,position), markup)
     scale
 end
-function push!(scale::GtkScale, value, position)
+function push!(scale::GtkScale, value::Real, position)
     G_.add_mark(scale, value, convert(Gtk4.PositionType,position), nothing)
     scale
 end

--- a/src/lists.jl
+++ b/src/lists.jl
@@ -74,6 +74,7 @@ set_child(te::GtkTreeExpander, w) = G_.set_child(te, w)
 get_child(te::GtkTreeExpander) = G_.get_child(te)
 
 get_item(trl::GtkTreeListRow) = G_.get_item(trl)
+get_children(trl::GtkTreeListRow) = G_.get_children(trl)
 
 function GtkTreeListModel(root::GListModel, passthrough, autoexpand, create_func)
     create_cfunc = @cfunction(GtkTreeListModelCreateModelFunc, Ptr{GObject}, (Ptr{GObject},Ref{Function}))

--- a/src/lists.jl
+++ b/src/lists.jl
@@ -105,6 +105,9 @@ function CompareDataFunc(a, b, user_data)
     convert(Cint, ret)
 end
 
+# enums in GTK are so...
+Ordering(x::UInt32) = unsafe_trunc(Int16,0xffff)
+
 ## GtkListBox
 setindex!(lb::GtkListBox, w::GtkWidget, i::Integer) = (G_.insert(lb, w, i - 1); lb[i])
 getindex(lb::GtkListBox, i::Integer) = G_.get_row_at_index(lb, i - 1)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,6 @@
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
+ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 ModernGL = "66fc600b-dfda-50eb-8b99-91cfa97b1301"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/test/gui/examples.jl
+++ b/test/gui/examples.jl
@@ -40,7 +40,7 @@ end
 
 @testset "Filtered List View" begin
     include(joinpath(@__DIR__, "..", "..", "examples", "filteredlistview.jl"))
-    @test Gtk4.G_.match(filter,Gtk4.GLib.G_.get_item(GListModel(model),0))
+    @test Gtk4.G_.match(filt,Gtk4.GLib.G_.get_item(GListModel(model),0))
     destroy(win)
 end
 
@@ -52,6 +52,12 @@ end
 
 @testset "Column View" begin
     include(joinpath(@__DIR__, "..", "..", "examples", "columnview.jl"))
+    destroy(win)
+end
+
+@testset "List View with TreeListModel" begin
+    include(joinpath(@__DIR__, "..", "..", "examples", "filteredlistview_tree.jl"))
+    @test match(Gtk4.G_.get_row(treemodel,0))
     destroy(win)
 end
 

--- a/test/gui/examples.jl
+++ b/test/gui/examples.jl
@@ -44,6 +44,12 @@ end
     destroy(win)
 end
 
+@testset "Sorted List View" begin
+    include(joinpath(@__DIR__, "..", "..", "examples", "sortedlistview.jl"))
+    @test Gtk4.G_.compare(sorter,Gtk4.GLib.G_.get_item(GListModel(model),0), Gtk4.GLib.G_.get_item(GListModel(model),1))
+    destroy(win)
+end
+
 @testset "Listbox" begin
     include(joinpath(@__DIR__, "..", "..", "examples", "listbox.jl"))
     destroy(main_window)

--- a/test/gui/examples.jl
+++ b/test/gui/examples.jl
@@ -46,7 +46,12 @@ end
 
 @testset "Sorted List View" begin
     include(joinpath(@__DIR__, "..", "..", "examples", "sortedlistview.jl"))
-    @test Gtk4.G_.compare(sorter,Gtk4.GLib.G_.get_item(GListModel(model),0), Gtk4.GLib.G_.get_item(GListModel(model),1))
+    @test Gtk4.G_.compare(sorter,Gtk4.GLib.G_.get_item(GListModel(model),0), Gtk4.GLib.G_.get_item(GListModel(model),1)) == -1
+    destroy(win)
+end
+
+@testset "Column View" begin
+    include(joinpath(@__DIR__, "..", "..", "examples", "columnview.jl"))
     destroy(win)
 end
 


### PR DESCRIPTION
In callbacks (_not_ signal handlers, these are function inputs to methods that get called by the C libraries) we have had to convert pointer arguments to GObjects and return pointers rather than the GObjects. This modifies the GI-generated callback functions to do that automatically, which makes the user-supplied callbacks shorter and cleaner. This also automatically adds a reference to GObject pointers on the output where appropriate. The lack of this extra reference was causing segfaults for me in GtkListViews that used GtkTreeListModel. I'm thinking for consistency this should be done in the `@cfunction` based signal handlers too. This is a breaking change since it affects how callbacks should be written.

Also adds some crude documentation for GtkListView, GtkColumnView, GtkCustomFilter, and GtkCustomSorter and miscellaneous other fixes.