### PR TITLE
set GTK_PATH so GTK4 finds print and media backends on Linux and OSX

### DIFF
--- a/src/Gtk4.jl
+++ b/src/Gtk4.jl
@@ -133,6 +133,13 @@ function __init__()
          Base.get(ENV, "XDG_DATA_DIRS", nothing)::Union{String,Nothing},
      ]), Sys.iswindows() ? ";" : ":")
 
+    # Help GTK find modules for printing, media, and input backends
+    # May have consequences for GTK3 programs spawned by Julia
+    ENV["GTK_PATH"] = joinpath(dirname(GTK4_jll.libgtk4_path::String),"gtk-4.0")
+
+    # Following also works for finding the printing backends (and also may affect GTK3 programs)
+    #ENV["GTK_EXE_PREFIX"] = GTK4_jll.artifact_dir
+
     gtype_wrapper_cache_init()
     gboxed_cache_init()
 

--- a/src/Gtk4.jl
+++ b/src/Gtk4.jl
@@ -133,12 +133,14 @@ function __init__()
          Base.get(ENV, "XDG_DATA_DIRS", nothing)::Union{String,Nothing},
      ]), Sys.iswindows() ? ";" : ":")
 
-    # Help GTK find modules for printing, media, and input backends
-    # May have consequences for GTK3 programs spawned by Julia
-    ENV["GTK_PATH"] = joinpath(dirname(GTK4_jll.libgtk4_path::String),"gtk-4.0")
-
-    # Following also works for finding the printing backends (and also may affect GTK3 programs)
-    #ENV["GTK_EXE_PREFIX"] = GTK4_jll.artifact_dir
+    if !Sys.iswindows()
+        # Help GTK find modules for printing, media, and input backends
+        # May have consequences for GTK3 programs spawned by Julia
+        ENV["GTK_PATH"] = joinpath(dirname(GTK4_jll.libgtk4_path::String),"gtk-4.0")
+        
+        # Following also works for finding the printing backends (and also may affect GTK3 programs)
+        #ENV["GTK_EXE_PREFIX"] = GTK4_jll.artifact_dir
+    end
 
     gtype_wrapper_cache_init()
     gboxed_cache_init()


### PR DESCRIPTION
This sets an environmental variable to help GTK4 find print and media backends installed by GTK4_jll on Linux and OSX. Currently this only enables "print to file" but if CUPS is added to Yggdrasil this should enable that too.

Inspired by #60 but does not really fix it.

Amusingly, on Windows printing already seems to work without this.