### PR TITLE
improve HDF5Viewer, add lock for await_finalize

### DIFF
--- a/examples/HDF5Viewer/Project.toml
+++ b/examples/HDF5Viewer/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 [deps]
 Gtk4 = "9db2cae5-386f-4011-9d63-a5602296539b"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 Gtk4 = "0.6"

--- a/src/GLib/gtype.jl
+++ b/src/GLib/gtype.jl
@@ -242,6 +242,7 @@ function glib_ref_sink(x::Ptr{GObject})
 end
 const gc_preserve_glib = Dict{Union{WeakRef, GObject}, Bool}() # glib objects
 const gc_preserve_glib_lock = Ref(false) # to satisfy this lock, must never decrement a ref counter while it is held
+const await_lock = ReentrantLock()
 const topfinalizer = Ref(true) # keep recursion to a minimum by only iterating from the top
 const await_finalize = Set{Any}()
 
@@ -271,7 +272,12 @@ function delref(@nospecialize(x::GObject))
     # internal helper function
     exiting[] && return # unnecessary to cleanup if we are about to die anyways
     if gc_preserve_glib_lock[] || g_yielded[]
-        push!(await_finalize, x)
+        lock(await_lock)
+        try
+            push!(await_finalize, x)
+        finally
+            unlock(await_lock)
+        end
         return # avoid running finalizers at random times
     end
     finalize_gc_unref(x)
@@ -296,7 +302,12 @@ function gobject_ref(x::T) where T <: GObject
         if ccall((:g_object_get_qdata, libgobject), Ptr{Cvoid},
                  (Ptr{GObject}, UInt32), x, jlref_quark::UInt32) != C_NULL
             # have set up metadata for this before, but its weakref has been cleared. restore the ref.
-            delete!(await_finalize, x)
+            lock(await_lock)
+            try
+                delete!(await_finalize, x)
+            finally
+                unlock(await_lock)
+            end
             finalizer(delref, x)
             gc_preserve_glib[WeakRef(x)] = false # record the existence of the object, but allow the finalizer
         else
@@ -330,9 +341,14 @@ function run_delayed_finalizers()
         filter!(x->!(isa(x.first,WeakRef) && x.first.value === nothing),gc_preserve_glib)
         gc_preserve_glib_lock[] = false
     end
-    while !isempty(await_finalize)
-        x = pop!(await_finalize)
-        finalize_gc_unref(x)
+    lock(await_lock)
+    try
+        while !isempty(await_finalize)
+            x = pop!(await_finalize)
+            finalize_gc_unref(x)
+        end
+    finally
+        unlock(await_lock)
     end
     topfinalizer[] = true
 end


### PR DESCRIPTION
While trying to add more multithreading to the example HDF5Viewer, I ran into a crash. The code involves populating a GtkTreeModel in a separate thread, which triggers the finalizing code in that thread. Adding a lock around all operations involving the set "await_finalize" fixed it.

Judging by https://github.com/JuliaGraphics/Gtk.jl/issues/694 there is probably a lot more we need to do, but I am not sure what's the best strategy. This fixes my issue so I'll just add this for now.