### PR TITLE
Allow `gtk_init_check` to fail

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Gtk4"
 uuid = "9db2cae5-386f-4011-9d63-a5602296539b"
-version = "0.7.5"
+version = "0.7.6"
 
 [deps]
 BitFlags = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"

--- a/src/Gtk4.jl
+++ b/src/Gtk4.jl
@@ -187,7 +187,10 @@ function __init__()
     end
 
     success = ccall((:gtk_init_check, libgtk4), Cint, ()) != 0
-    #success || error("gtk_init_check() failed.")
+    if !success
+        @warn("Gtk4 initialization failed. Calling Gtk4 methods will cause Julia to crash.")
+        return
+    end
 
     if Sys.islinux() || Sys.isfreebsd()
         G_.set_default_icon_name("julia")
@@ -198,8 +201,6 @@ function __init__()
     GLib.G_.set_prgname("julia")
 
     isinteractive() && GLib.start_main_loop()
-
-    #@debug("Gtk4 initialized.")
 end
 
 isinitialized() = G_.is_initialized()

--- a/src/Gtk4.jl
+++ b/src/Gtk4.jl
@@ -136,6 +136,8 @@ function set_EGL_vendorlib_dirs(dirs)
     @info("Setting will take effect after restarting Julia.")
 end
 
+const initialized = Ref(false)  # whether `init_check` succeeded, not necessarily the same as GTK4's `is_initialized`
+
 function __init__()
     in("Gtk",[x.name for x in keys(Base.loaded_modules)]) && error("Gtk4 is incompatible with Gtk.")
 
@@ -186,8 +188,8 @@ function __init__()
         end
     end
 
-    success = ccall((:gtk_init_check, libgtk4), Cint, ()) != 0
-    if !success
+    initialized[] = ccall((:gtk_init_check, libgtk4), Cint, ()) != 0
+    if !initialized[]
         @warn("Gtk4 initialization failed. Calling Gtk4 methods will cause Julia to crash.")
         return
     end

--- a/src/Gtk4.jl
+++ b/src/Gtk4.jl
@@ -187,7 +187,7 @@ function __init__()
     end
 
     success = ccall((:gtk_init_check, libgtk4), Cint, ()) != 0
-    success || error("gtk_init_check() failed.")
+    #success || error("gtk_init_check() failed.")
 
     if Sys.islinux() || Sys.isfreebsd()
         G_.set_default_icon_name("julia")


### PR DESCRIPTION
A warning will be emitted rather than an error. Downstream packages can check `Gtk4.initialized[]` to see if it is safe to call Gtk4 methods.

Fixes #84 