### PR TITLE
test ARM Mac OS in CI, get tests working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
         include:
           - os: ubuntu-latest
             prefix: xvfb-run
-          - arch: "arm64"
-            os: "macOS-14"
-            version: "1.11"
+          - os: macOS-latest
+            julia-arch: aarch64
+            julia-version: '1'
         # 32-bit Julia binaries are not available on macOS
         exclude:
           - os: macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
         include:
           - os: ubuntu-latest
             prefix: xvfb-run
+          - arch: "arm64"
+            os: "macOS-14"
+            version: "1.11"
         # 32-bit Julia binaries are not available on macOS
         exclude:
           - os: macOS-latest

--- a/docs/src/manual/signals.md
+++ b/docs/src/manual/signals.md
@@ -86,7 +86,7 @@ end
 ## Alternative approach to signals and signal handlers
 
 !!! warning
-    This method and the one described in the next section rely on [closure cfunctions](https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/index.html#Closure-cfunctions), which are not supported on all platforms (including ARM). If you're writing code for those platforms, use the method described above. This may be fixed in a future version of Gtk4.
+    This methods in this section and the next section rely on [closure cfunctions](https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/index.html#Closure-cfunctions), which are not supported on all platforms (including ARM). If you're writing code for those platforms, use the method described above. This may be fixed in a future version of Gtk4.
 
 In addition to the "simple" interface described above, Gtk4 includes an approach that allows your callback function to be directly compiled to machine code. Gtk4 makes this easier by using GObject introspection data to look up the return type and parameter types, saving the user the hassle of doing this themselves.
 

--- a/docs/src/manual/signals.md
+++ b/docs/src/manual/signals.md
@@ -85,6 +85,9 @@ end
 
 ## Alternative approach to signals and signal handlers
 
+!!! warning
+    This method and the one described in the next section rely on [closure cfunctions](https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/index.html#Closure-cfunctions), which are not supported on all platforms (including ARM). If you're writing code for those platforms, use the method described above. This may be fixed in a future version of Gtk4.
+
 In addition to the "simple" interface described above, Gtk4 includes an approach that allows your callback function to be directly compiled to machine code. Gtk4 makes this easier by using GObject introspection data to look up the return type and parameter types, saving the user the hassle of doing this themselves.
 
 For the "clicked" signal of a `GtkButton`, the equivalent to the example at the beginning of this page is as follows:

--- a/src/GLib/gtype.jl
+++ b/src/GLib/gtype.jl
@@ -408,7 +408,7 @@ function gc_unref(x::GObject)
     if ref != C_NULL && x !== unsafe_pointer_to_objref(ref)
         # We got called because we are no longer the default object for this handle, but we are still alive
         @warn("Duplicate Julia object creation detected for GObject")
-        deref = cfunction_(gc_unref_weak, Nothing, (Ref{typeof(x)},))
+        deref = @cfunction(gc_unref_weak, Nothing, (Ref{GObject},))
         ccall((:g_object_weak_ref, libgobject), Nothing, (Ptr{GObject}, Ptr{Nothing}, Any), x, deref, x)
     else
         ccall((:g_object_steal_qdata, libgobject), Any, (Ptr{GObject}, UInt32), x, jlref_quark::UInt32)

--- a/test/action-group.jl
+++ b/test/action-group.jl
@@ -1,6 +1,10 @@
 using Gtk4.GLib
 using Test
 
+function can_use_closure_cfunction()
+    return !(Sys.ARCH === :aarch64 || Sys.ARCH === :armv7l || Sys.ARCH === :armv6l)
+end
+
 @testset "signal basics" begin
 
 @test signal_return_type(GObject, :notify) == Nothing
@@ -141,22 +145,26 @@ add_action(GActionMap(g), "new-action-with-parameter", Bool, cb)
 
 end
 
-@testset "add action cfunction" begin
-g=GLib.G_.SimpleActionGroup_new()
-extra_arg_ref=Ref(0)
+@static if can_use_closure_cfunction()
+    @testset "add action cfunction" begin
+    g=GLib.G_.SimpleActionGroup_new()
+    extra_arg_ref=Ref(0)
 
-action_added = Ref(false)
+    action_added = Ref(false)
 
-function action_added_cb2(action_group, action_name, extra_arg)
-    action_added[] = true
-    extra_arg_ref[] = extra_arg
-    nothing
+    function action_added_cb2(action_group, action_name, extra_arg)
+        action_added[] = true
+        extra_arg_ref[] = extra_arg
+        nothing
+    end
+
+    # test the more sophisticated `signal_connect`
+    GLib.on_action_added(action_added_cb2, g, 3)
+
+    end
+
 end
 
-# test the more sophisticated `signal_connect`
-GLib.on_action_added(action_added_cb2, g, 3)
-
-end
 
 @testset "add stateful action" begin
 
@@ -175,17 +183,17 @@ a5 = add_stateful_action(GActionMap(g), "new-action3-par", Bool, true, cb)
 
 end
 
-@testset "add stateful action cfunction" begin
+@static if can_use_closure_cfunction()
+    @testset "add stateful action cfunction" begin
 
-g=GLib.G_.SimpleActionGroup_new()
+    g=GLib.G_.SimpleActionGroup_new()
 
-function cb2(a,v,user_data)
-    nothing
-end
+    function cb2(a,v,user_data)
+        nothing
+    end
 
-add_stateful_action(GActionMap(g), "new-action4", true, cb2, 5)
-
-
+    add_stateful_action(GActionMap(g), "new-action4", true, cb2, 5)
+    end
 end
 
 @testset "GListStore" begin


### PR DESCRIPTION
Test ARM Mac OS in CI and disable tests of closure cfunction based signal connectors on ARM. Also change one use of a closure cfunction to use an ordinary cfunction (which is maybe more efficient anyway?). Finally, add a warning in the documentation about the closure cfunction based signal connectors.

This helps with #95 but is not yet a full fix.