### PR TITLE
Comment out run_delayed_finalizers in gobject_ref

### DIFF
--- a/src/GLib/gtype.jl
+++ b/src/GLib/gtype.jl
@@ -368,7 +368,7 @@ function gobject_ref(x::T) where T <: GObject
         # already gc-protected, nothing to do
     end
     gc_preserve_glib_lock[] = false
-    run_delayed_finalizers()
+    # run_delayed_finalizers() # Commenting out helps with issue #99, unsure why
     return x
 end
 gc_ref(x::GObject) = pointer_from_objref(gobject_ref(x))


### PR DESCRIPTION
When I comment out the finalizers as done in the first commit, I can't reproduce issue #99 anymore.

But I am completely unsure why this works and if it has any other unintended side effects 🙈 I tried to understand the glib setup a bit better, but I think I'd need more time with it. It looks like the finalizeres are in this setting calling other finalizers again and breaking things