### PR TITLE
Add documentation hint to make UI files relocatable

### DIFF
--- a/docs/src/manual/builder.md
+++ b/docs/src/manual/builder.md
@@ -38,7 +38,8 @@ b = GtkBuilder("path/to/myapp.ui")
 !!! note
     If you are developing the code in a package you can get the package directory using the `@__DIR__` macro.
     For instance, if your UI file is located at `MyPackage/src/builder/myuifile.ui`, you can get the full path using
-    `uifile = joinpath(@__DIR__, "builder", "myuifile.ui")`.
+    `uifile = joinpath(@__DIR__, "builder", "myuifile.ui")`. If you plan to create an executable application of your package using PackageCompiler,
+    ensure that your UI file is relocatable by utilizing Artifacts.jl or RelocatableFolders.jl. For further details, please refer to the documentation of the respective packages.
 
 Alternatively, if we store the above XML definition in a Julia string `myapp` we can initialize
 the builder by


### PR DESCRIPTION
Hello,

I've been playing around a bit with PackageCompiler and one easy mistake to make when trying to distribute an Gtk4 app is too use just `joinpath(@__DIR__, "...", "file.ui")`. Since `@__DIR__` is evaluated at compile time, it is then hardcoded to some path.

To make users aware of this, especialyl because I tihnk GUI are a good case for PackageCompiler, I've added a hint to the documentation that mentions this issue or rather mentions solutions for the problem.