### PR TITLE
fix warn

### DIFF
--- a/src/GLib/loop.jl
+++ b/src/GLib/loop.jl
@@ -160,7 +160,7 @@ Pauses the GLib event loop around a function. Restores the original state of the
 function pause_main_loop(f)
     was_running = is_loop_running()
     if was_running && g_main_running[] == false
-        warn("GLib main loop is running, but not via `glib_main`. Pausing the main loop inside a GApplication is not currently supported, so the function will be called without pausing.")
+        @warn("GLib main loop is running, but not via `glib_main`. Pausing the main loop inside a GApplication is not currently supported, so the function will be called without pausing.")
         f()
         return
     end


### PR DESCRIPTION
I got an error

```julia
ERROR: UndefVarError: `warn` not defined
Stacktrace:
 [1] pause_main_loop(f::ProfileView.var"#7#8")
   @ Gtk4.GLib ~/.julia/packages/Gtk4/BHOnE/src/GLib/loop.jl:163
 [2] view(; kwargs::@Kwargs{windowname::String})
   @ ProfileView ~/.julia/packages/ProfileView/eDYNi/src/ProfileView.jl:210
 [3] macro expansion
   @ ~/.julia/packages/ProfileView/eDYNi/src/ProfileView.jl:125 [inlined]
 [4] top-level scope
   @ REPL[14]:1
```

This PR should fix it.