### PR TITLE
prevent adding methods to the functions `>` and `>=`

### DIFF
--- a/src/GLib/gvariant.jl
+++ b/src/GLib/gvariant.jl
@@ -36,8 +36,6 @@ GVariant(::Type{T},x) where T = GVariant(convert(T, x))
 Base.:(==)(lhs::GVariant, rhs::GVariant) = G_.equal(lhs,rhs)
 Base.:(<)(lhs::GVariant, rhs::GVariant) = G_.compare(lhs, rhs) < 0
 Base.:(<=)(lhs::GVariant, rhs::GVariant) = G_.compare(lhs, rhs) <= 0
-Base.:(>)(lhs::GVariant, rhs::GVariant) = G_.compare(lhs, rhs) > 0
-Base.:(>=)(lhs::GVariant, rhs::GVariant) = G_.compare(lhs, rhs) >= 0
 
 variant_type_string(::Type{Bool}) = "b"
 variant_type_string(::Type{UInt8}) = "y"

--- a/src/text.jl
+++ b/src/text.jl
@@ -152,8 +152,6 @@ end
 Base.:(==)(lhs::TI, rhs::TI) = G_.equal(lhs, rhs)
 Base.:(<)(lhs::TI, rhs::TI) = G_.compare(lhs, rhs) < 0
 Base.:(<=)(lhs::TI, rhs::TI) = G_.compare(lhs, rhs) <= 0
-Base.:(>)(lhs::TI, rhs::TI) = G_.compare(lhs, rhs) > 0
-Base.:(>=)(lhs::TI, rhs::TI) = G_.compare(lhs, rhs) >= 0
 
 start_(iter::TI) = Ref(iter)
 iterate(::TI, iter=start_(iter)) = iter.is_end ? nothing : (iter.char, iter + 1)


### PR DESCRIPTION
As documented, the intended way to implement `>` is to add a method to `<`. Similarly with `>=`. A package should never add a method to either `>` or `>=`.